### PR TITLE
Add portal input dataset management and reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,51 @@ python examples/run_sample_workflow.py
 运行结束后可直接查看 `results/example_run` 目录下的 CSV、图表与报告，
 用于快速了解模型参数、情景配置及准确性分析的效果。
 
+
+## 自然语言门户原型
+
+仓库新增了基于最小依赖实现的 Web 门户（`hydrosis.portal`），包含
+
+- `hydrosis/portal/main.py`：提供 REST 风格 API，支持会话解析、项目配置、情景管理与模型运行；
+- `hydrosis/portal/static/index.html`：轻量化的前端页面，可直接通过表单与 API 交互；
+- `fastapi/`：内置的极简 FastAPI 兼容层，在离线环境也能运行同样的接口定义。
+
+快速体验步骤：
+
+```bash
+python -m http.server 8000 --directory hydrosis/portal/static  # 也可自定义部署方式
+```
+
+或使用任意 ASGI/WGI 兼容方案加载 `hydrosis.portal.create_app()` 创建的应用。
+API 支持的关键资源包括：
+
+- `GET /projects`：列出当前门户中注册的所有项目；
+- `POST /projects/{project_id}/config`：保存或更新模型配置；
+- `POST /projects/{project_id}/inputs` 与 `GET /projects/{project_id}/inputs`：集中管理项目的入流与观测数据；
+- `POST /projects/{project_id}/scenarios` / `PUT` / `DELETE`：创建、更新或删除情景；
+- `GET /projects/{project_id}/scenarios`：查看情景清单；
+- `POST /projects/{project_id}/runs`：触发建模计算；
+- `GET /projects/{project_id}/runs` 与 `GET /runs`：查看运行历史与最新状态；
+- `GET /runs/{run_id}`、`/runs/{run_id}/report`、`/runs/{run_id}/figures`：查询结果详情与输出。
+- `GET /runs/{run_id}/summary`：提炼基准与情景运行的主要统计量与差异摘要。
+
+静态页面中的“水文输入管理”区域可集中维护降雨/观测序列，之后在“触发模拟”区域提交运行时即可复用，无需重复粘贴时间序列。运行完成后页面会自动填充运行 ID，并可直接查看新增的摘要输出，便于快速理解情景相对于基准的变化。
+
+单元测试 `tests/test_portal_api.py` 展示了如何以编程方式驱动该门户：
+
+```python
+from hydrosis.portal import create_app
+from fastapi.testclient import TestClient
+
+app = create_app()
+client = TestClient(app)
+client.post('/projects/demo/config', json={'model': {...}})
+client.post('/projects/demo/inputs', json={'forcing': {...}, 'observations': {...}})
+client.post('/projects/demo/runs', json={'scenario_ids': ['alternate_routing']})
+```
+
+这样即可在无外部依赖的环境下完成自然语言解析、建模运行和结果查询的端到端链路。
+
 ## 参数区多目标优化与不确定性分析
 
 `hydrosis.parameters` 包提供 `ParameterZoneOptimizer` 与 `UncertaintyAnalyzer`

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,0 +1,6 @@
+"""Minimal FastAPI-compatible shim for testing without external dependency."""
+from __future__ import annotations
+
+from .app import FastAPI, HTTPException, Response
+
+__all__ = ["FastAPI", "HTTPException", "Response"]

--- a/fastapi/app.py
+++ b/fastapi/app.py
@@ -1,0 +1,177 @@
+"""Simplified ASGI-like application emulating FastAPI for tests."""
+from __future__ import annotations
+
+import inspect
+import re
+from dataclasses import dataclass, asdict, is_dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+try:
+    from pydantic import BaseModel
+except ImportError:  # pragma: no cover - test environment always includes pydantic
+    BaseModel = object  # type: ignore
+
+
+class HTTPException(Exception):
+    """Exception carrying an HTTP status code and payload."""
+
+    def __init__(self, status_code: int, detail: str | Mapping[str, Any]) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+@dataclass
+class _Route:
+    method: str
+    path: str
+    handler: Callable[..., Any]
+    response_model: Any = None
+    response_class: Any = None
+
+    def match(self, request_path: str) -> Optional[Dict[str, str]]:
+        pattern = re.sub(r"{([^}]+)}", r"(?P<\1>[^/]+)", self.path)
+        match = re.fullmatch(pattern, request_path)
+        if match:
+            return match.groupdict()
+        return None
+
+
+class FastAPI:
+    """Very small subset of the FastAPI interface used in tests."""
+
+    def __init__(self, title: str = "FastAPI", version: str = "0.0.0") -> None:
+        self.title = title
+        self.version = version
+        self._routes: List[_Route] = []
+        self._mounts: List[Tuple[str, object]] = []
+
+    # Route registration -------------------------------------------------
+    def get(
+        self,
+        path: str,
+        response_model: Any | None = None,
+        response_class: Any | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        return self._add_route("GET", path, response_model, response_class)
+
+    def post(
+        self,
+        path: str,
+        response_model: Any | None = None,
+        response_class: Any | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        return self._add_route("POST", path, response_model, response_class)
+
+    def put(
+        self,
+        path: str,
+        response_model: Any | None = None,
+        response_class: Any | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        return self._add_route("PUT", path, response_model, response_class)
+
+    def delete(
+        self,
+        path: str,
+        response_model: Any | None = None,
+        response_class: Any | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        return self._add_route("DELETE", path, response_model, response_class)
+
+    def _add_route(
+        self,
+        method: str,
+        path: str,
+        response_model: Any | None,
+        response_class: Any | None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self._routes.append(
+                _Route(method=method, path=path, handler=func, response_model=response_model, response_class=response_class)
+            )
+            return func
+
+        return decorator
+
+    def mount(self, path: str, app: object, name: str | None = None) -> None:  # pragma: no cover - behaviour unused in tests
+        self._mounts.append((path, app))
+
+    # Request handling ---------------------------------------------------
+    def handle_request(self, method: str, path: str, body: Any | None = None) -> "Response":
+        for route in self._routes:
+            if route.method != method:
+                continue
+            path_params = route.match(path)
+            if path_params is None:
+                continue
+            try:
+                payload = self._build_payload(route.handler, path_params, body)
+                result = route.handler(**payload)
+                return _normalise_response(result, route.response_class)
+            except HTTPException as exc:
+                return Response(status_code=exc.status_code, data={"detail": exc.detail})
+        return Response(status_code=404, data={"detail": "Not Found"})
+
+    def _build_payload(
+        self,
+        handler: Callable[..., Any],
+        path_params: Mapping[str, str],
+        body: Any | None,
+    ) -> Dict[str, Any]:
+        signature = inspect.signature(handler)
+        arguments: Dict[str, Any] = dict(path_params)
+        if body is None:
+            return arguments
+        for name, parameter in signature.parameters.items():
+            if name in arguments:
+                continue
+            annotation = parameter.annotation
+            if annotation is inspect.Signature.empty:
+                arguments[name] = body
+                continue
+            if isinstance(annotation, type) and _is_pydantic_model(annotation):
+                arguments[name] = annotation(**body)
+            elif isinstance(annotation, type) and is_dataclass(annotation):
+                arguments[name] = annotation(**body)
+            else:
+                arguments[name] = body
+        return arguments
+
+
+@dataclass
+class Response:
+    status_code: int
+    data: Any
+
+    def json(self) -> Any:
+        return self.data
+
+    @property
+    def text(self) -> str:
+        if isinstance(self.data, str):
+            return self.data
+        return str(self.data)
+
+
+def _normalise_response(result: Any, response_class: Any | None) -> Response:
+    if isinstance(result, Response):
+        return result
+    if is_dataclass(result):
+        return Response(status_code=200, data=asdict(result))
+    if BaseModel is not object and isinstance(result, BaseModel):  # type: ignore[isinstance]
+        return Response(status_code=200, data=result.dict())
+    if hasattr(result, "to_dict") and callable(result.to_dict):
+        return Response(status_code=200, data=result.to_dict())
+    if hasattr(result, "dict") and callable(result.dict):
+        return Response(status_code=200, data=result.dict())
+    if isinstance(result, (dict, list, str)):
+        return Response(status_code=200, data=result)
+    return Response(status_code=200, data=result)
+
+
+def _is_pydantic_model(cls: Any) -> bool:
+    return BaseModel is not object and isinstance(cls, type) and issubclass(cls, BaseModel)
+
+
+__all__ = ["FastAPI", "HTTPException", "Response"]

--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -1,0 +1,17 @@
+"""Minimal response classes used by the shimmed FastAPI implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HTMLResponse:
+    """Simple wrapper carrying HTML content."""
+
+    content: str
+
+    def __iter__(self):  # pragma: no cover - unused in tests
+        yield self.content
+
+
+__all__ = ["HTMLResponse"]

--- a/fastapi/staticfiles.py
+++ b/fastapi/staticfiles.py
@@ -1,0 +1,18 @@
+"""Static file mount placeholder used to mirror FastAPI's API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class StaticFiles:
+    """Store the directory path for mounted static assets."""
+
+    directory: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive
+        Path(self.directory).resolve()
+
+
+__all__ = ["StaticFiles"]

--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -1,0 +1,51 @@
+"""Tiny synchronous test client emulating fastapi.testclient behaviour."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from .app import FastAPI
+
+
+@dataclass
+class _ClientResponse:
+    status_code: int
+    data: Any
+
+    def json(self) -> Any:
+        return self.data
+
+    @property
+    def text(self) -> str:
+        if isinstance(self.data, str):
+            return self.data
+        return json.dumps(self.data, ensure_ascii=False)
+
+
+class TestClient:
+    """Provide a minimal requests-like interface for tests."""
+
+    __test__ = False
+
+    def __init__(self, app: FastAPI) -> None:
+        self._app = app
+
+    def get(self, path: str) -> _ClientResponse:
+        response = self._app.handle_request("GET", path)
+        return _ClientResponse(status_code=response.status_code, data=response.json())
+
+    def post(self, path: str, json: Optional[Mapping[str, Any]] = None) -> _ClientResponse:
+        response = self._app.handle_request("POST", path, body=dict(json or {}))
+        return _ClientResponse(status_code=response.status_code, data=response.json())
+
+    def put(self, path: str, json: Optional[Mapping[str, Any]] = None) -> _ClientResponse:
+        response = self._app.handle_request("PUT", path, body=dict(json or {}))
+        return _ClientResponse(status_code=response.status_code, data=response.json())
+
+    def delete(self, path: str) -> _ClientResponse:
+        response = self._app.handle_request("DELETE", path)
+        return _ClientResponse(status_code=response.status_code, data=response.json())
+
+
+__all__ = ["TestClient"]

--- a/hydrosis/portal/__init__.py
+++ b/hydrosis/portal/__init__.py
@@ -1,0 +1,6 @@
+"""Portal web application wiring for HydroSIS."""
+from __future__ import annotations
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/hydrosis/portal/analytics.py
+++ b/hydrosis/portal/analytics.py
@@ -1,0 +1,139 @@
+"""Utilities for summarising workflow results for presentation in the portal."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+from hydrosis.workflow import ScenarioRun, WorkflowResult
+
+from .state import serialize_evaluation_outcome, serialize_model_score
+
+Series = Iterable[float]
+
+
+def summarise_workflow_result(result: WorkflowResult) -> Dict[str, object]:
+    """Build a compact summary of a :class:`WorkflowResult` for API responses."""
+
+    baseline_summary = _summarise_scenario_run(result.baseline)
+    scenario_summaries = {
+        scenario_id: _summarise_scenario_run(run)
+        for scenario_id, run in result.scenarios.items()
+    }
+
+    deltas = _compute_deltas(baseline_summary["aggregated"], scenario_summaries)
+
+    return {
+        "baseline": baseline_summary,
+        "scenarios": {
+            scenario_id: {
+                **summary,
+                "delta_vs_baseline": deltas.get(scenario_id, {}),
+            }
+            for scenario_id, summary in scenario_summaries.items()
+        },
+        "overall_scores": [
+            serialize_model_score(score) for score in result.overall_scores or []
+        ],
+        "evaluation_outcomes": [
+            serialize_evaluation_outcome(outcome)
+            for outcome in result.evaluation_outcomes
+        ],
+        "narrative": _build_narrative(scenario_summaries, deltas),
+    }
+
+
+def _summarise_scenario_run(run: ScenarioRun) -> Dict[str, MutableMapping[str, object]]:
+    return {
+        "scenario_id": run.scenario_id,
+        "aggregated": {
+            subbasin: _summarise_series(series)
+            for subbasin, series in run.aggregated.items()
+        },
+        "zone_discharge": {
+            zone: {
+                subbasin: _summarise_series(series)
+                for subbasin, series in flows.items()
+            }
+            for zone, flows in run.zone_discharge.items()
+        },
+    }
+
+
+def _summarise_series(series: Series) -> Dict[str, object]:
+    values = [float(value) for value in series]
+    if not values:
+        return {
+            "total_volume": 0.0,
+            "mean_flow": 0.0,
+            "peak_flow": 0.0,
+            "peak_index": None,
+        }
+    total = float(sum(values))
+    peak_flow = max(values)
+    peak_index = values.index(peak_flow)
+    mean_flow = total / len(values)
+    return {
+        "total_volume": total,
+        "mean_flow": mean_flow,
+        "peak_flow": peak_flow,
+        "peak_index": peak_index,
+    }
+
+
+def _compute_deltas(
+    baseline: Mapping[str, Mapping[str, float]],
+    scenarios: Mapping[str, Mapping[str, Mapping[str, float]]],
+) -> Dict[str, Dict[str, Dict[str, float]]]:
+    deltas: Dict[str, Dict[str, Dict[str, float]]] = {}
+    for scenario_id, summary in scenarios.items():
+        aggregated = summary.get("aggregated", {})
+        scenario_deltas: Dict[str, Dict[str, float]] = {}
+        for subbasin, stats in aggregated.items():
+            if subbasin not in baseline:
+                continue
+            base_stats = baseline[subbasin]
+            scenario_deltas[subbasin] = {
+                key: float(stats.get(key, 0.0)) - float(base_stats.get(key, 0.0))
+                for key in ("total_volume", "mean_flow", "peak_flow")
+            }
+        deltas[scenario_id] = scenario_deltas
+    return deltas
+
+
+def _build_narrative(
+    scenarios: Mapping[str, Mapping[str, object]],
+    deltas: Mapping[str, Mapping[str, Mapping[str, float]]],
+) -> str:
+    if not scenarios:
+        return "仅运行了基准情景，尚无情景对比可供总结。"
+
+    parts = [
+        "基准情景的主要指标已记录，可对比以下情景的变化：",
+    ]
+    for scenario_id, summary in scenarios.items():
+        delta = deltas.get(scenario_id, {})
+        if not delta:
+            parts.append(f"- 情景 {scenario_id} 与基准在聚合流量上差异很小。")
+            continue
+        highlights = []
+        for subbasin, stats in delta.items():
+            volume_change = stats.get("total_volume", 0.0)
+            peak_change = stats.get("peak_flow", 0.0)
+            descriptor = []
+            if abs(volume_change) > 1e-6:
+                descriptor.append(
+                    f"总径流{'增加' if volume_change >= 0 else '减少'} {abs(volume_change):.2f}"
+                )
+            if abs(peak_change) > 1e-6:
+                descriptor.append(
+                    f"峰值流量{'升高' if peak_change >= 0 else '降低'} {abs(peak_change):.2f}"
+                )
+            if descriptor:
+                highlights.append(f"子流域 {subbasin}：{'，'.join(descriptor)}")
+        if highlights:
+            parts.append(f"- 情景 {scenario_id} 的主要变化：" + "；".join(highlights) + "。")
+        else:
+            parts.append(f"- 情景 {scenario_id} 的变化在统计量上不显著。")
+    return "\n".join(parts)
+
+
+__all__ = ["summarise_workflow_result"]

--- a/hydrosis/portal/llm.py
+++ b/hydrosis/portal/llm.py
@@ -1,0 +1,52 @@
+"""Lightweight natural language interpreter used by the portal."""
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+
+class IntentParser:
+    """Rule-based interpreter translating chat messages into structured intents."""
+
+    def __init__(self) -> None:
+        self._scenario_pattern = re.compile(r"scenario[s]?\s+([\w,\- ]+)", re.IGNORECASE)
+
+    def parse(self, message: str) -> Dict[str, object]:
+        """Return a structured representation of the requested action."""
+
+        lowered = message.lower()
+        if any(keyword in lowered for keyword in ["run", "simulate", "execute", "运行", "模拟"]):
+            scenario_ids = self._extract_scenarios(message)
+            return {
+                "action": "run_scenarios",
+                "parameters": {"scenario_ids": scenario_ids} if scenario_ids else {},
+                "confidence": 0.6 if scenario_ids else 0.4,
+            }
+        if "create" in lowered and "scenario" in lowered:
+            name = self._extract_name(message)
+            return {
+                "action": "create_scenario",
+                "parameters": {"name": name} if name else {},
+                "confidence": 0.5,
+            }
+        if "list" in lowered and "scenario" in lowered:
+            return {"action": "list_scenarios", "parameters": {}, "confidence": 0.7}
+        if "report" in lowered or "summary" in lowered:
+            return {"action": "summarise_results", "parameters": {}, "confidence": 0.5}
+        return {"action": "general_chat", "parameters": {}, "confidence": 0.2}
+
+    def _extract_scenarios(self, message: str) -> List[str]:
+        match = self._scenario_pattern.search(message)
+        if not match:
+            return []
+        candidates = re.split(r"[,\s]+", match.group(1).strip())
+        return [item for item in candidates if item]
+
+    def _extract_name(self, message: str) -> str | None:
+        name_match = re.search(r"scenario\s+(?:called|named)?\s*([\w\-]+)", message, re.IGNORECASE)
+        if name_match:
+            return name_match.group(1)
+        return None
+
+
+__all__ = ["IntentParser"]

--- a/hydrosis/portal/main.py
+++ b/hydrosis/portal/main.py
@@ -1,0 +1,403 @@
+"""FastAPI application exposing the HydroSIS portal."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Mapping, List
+
+from fastapi import FastAPI, HTTPException, Response
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
+from hydrosis.config import ModelConfig
+from hydrosis.workflow import run_workflow, WorkflowResult
+
+from .analytics import summarise_workflow_result
+from .llm import IntentParser
+from .schemas import (
+    ConversationMessageSchema,
+    ConversationResponse,
+    ProjectInputsPayload,
+    ProjectInputsResponse,
+    ProjectList,
+    ProjectConfigPayload,
+    ProjectSummary,
+    RunRequest,
+    RunResponse,
+    RunList,
+    ScenarioCreatePayload,
+    ScenarioList,
+    ScenarioUpdatePayload,
+)
+from .state import ConversationMessage, PortalState
+
+
+
+def _remove_none(obj):
+    if isinstance(obj, dict):
+        return {key: _remove_none(value) for key, value in obj.items() if value is not None}
+    if isinstance(obj, list):
+        return [_remove_none(item) for item in obj]
+    return obj
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+def create_app(state: PortalState | None = None) -> FastAPI:
+    app = FastAPI(title="HydroSIS Portal", version="0.1.0")
+
+    portal_state = state or PortalState()
+    intent_parser = IntentParser()
+
+    if STATIC_DIR.exists():
+        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+    @app.get("/", response_class=HTMLResponse)
+    def index() -> str:
+        index_path = STATIC_DIR / "index.html"
+        if not index_path.exists():
+            raise HTTPException(status_code=404, detail="Portal assets not found")
+        return index_path.read_text(encoding="utf-8")
+
+    @app.post("/conversations/{conversation_id}/messages", response_model=ConversationResponse)
+    def post_message(
+        conversation_id: str, payload: ConversationMessageSchema | dict
+    ) -> ConversationResponse:
+        if isinstance(payload, dict):
+            payload = ConversationMessageSchema.from_dict(payload)
+        conversation = portal_state.get_conversation(conversation_id)
+        user_message = ConversationMessage(role=payload.role, content=payload.content)
+        conversation.add(user_message)
+
+        intent = intent_parser.parse(payload.content)
+
+        reply = _render_assistant_reply(intent, conversation_id)
+        assistant_message = ConversationMessage(role="assistant", content=reply, intent=intent)
+        conversation.add(assistant_message)
+
+        return ConversationResponse(
+            reply=reply,
+            intent=intent,
+            messages=[
+                ConversationMessageSchema(
+                    role=msg.role, content=msg.content, intent=msg.intent
+                )
+                for msg in conversation.messages
+            ],
+        )
+
+    @app.get("/conversations/{conversation_id}", response_model=ConversationResponse)
+    def get_conversation(conversation_id: str) -> ConversationResponse:
+        conversation = portal_state.get_conversation(conversation_id)
+        intent = conversation.messages[-1].intent if conversation.messages else {}
+        return ConversationResponse(
+            reply=conversation.messages[-1].content if conversation.messages else "",
+            intent=intent or {},
+            messages=[
+                ConversationMessageSchema(
+                    role=msg.role, content=msg.content, intent=msg.intent
+                )
+                for msg in conversation.messages
+            ],
+        )
+
+    @app.get("/projects", response_model=ProjectList)
+    def list_projects() -> ProjectList:
+        projects = [
+            ProjectSummary(**project.to_summary())
+            for project in portal_state.list_projects()
+        ]
+        return ProjectList(projects=projects)
+
+    @app.post(
+        "/projects/{project_id}/inputs",
+        response_model=ProjectInputsResponse,
+    )
+    def upsert_inputs(
+        project_id: str, payload: ProjectInputsPayload | dict
+    ) -> ProjectInputsResponse:
+        if isinstance(payload, dict):
+            payload = ProjectInputsPayload.from_dict(payload)
+        try:
+            existing = portal_state.get_inputs(project_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        observations = payload.observations
+        if observations is None and existing is not None:
+            observations = existing.observations
+        dataset = portal_state.set_inputs(
+            project_id,
+            payload.forcing,
+            observations,
+        )
+        return ProjectInputsResponse(
+            forcing=dataset.forcing,
+            observations=dataset.observations,
+            updated_at=dataset.updated_at.isoformat(),
+        )
+
+    @app.get("/projects/{project_id}/inputs", response_model=ProjectInputsResponse)
+    def get_inputs(project_id: str) -> ProjectInputsResponse:
+        try:
+            dataset = portal_state.get_inputs(project_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        if dataset is None:
+            raise HTTPException(status_code=404, detail="Inputs not configured")
+        return ProjectInputsResponse(
+            forcing=dataset.forcing,
+            observations=dataset.observations,
+            updated_at=dataset.updated_at.isoformat(),
+        )
+
+    @app.post("/projects/{project_id}/config", response_model=ProjectSummary)
+    def upsert_project(project_id: str, payload: ProjectConfigPayload | dict) -> ProjectSummary:
+        if isinstance(payload, dict):
+            payload = ProjectConfigPayload.from_dict(payload)
+        model_config = ModelConfig.from_dict(_remove_none(payload.model))
+        project = portal_state.upsert_project(project_id, payload.name, model_config)
+        return ProjectSummary(**project.to_summary())
+
+    @app.get("/projects/{project_id}", response_model=ProjectSummary)
+    def get_project(project_id: str) -> ProjectSummary:
+        try:
+            project = portal_state.get_project(project_id)
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return ProjectSummary(**project.to_summary())
+
+    @app.get("/projects/{project_id}/scenarios", response_model=ScenarioList)
+    def list_scenarios(project_id: str) -> ScenarioList:
+        scenarios = portal_state.list_scenarios(project_id)
+        return ScenarioList(
+            scenarios=[
+                ScenarioCreatePayload(
+                    id=scenario.id,
+                    description=scenario.description,
+                    modifications=scenario.modifications,
+                )
+                for scenario in scenarios
+            ]
+        )
+
+    @app.post("/projects/{project_id}/scenarios", response_model=ScenarioCreatePayload)
+    def create_scenario(
+        project_id: str, payload: ScenarioCreatePayload | dict
+    ) -> ScenarioCreatePayload:
+        if isinstance(payload, dict):
+            payload = ScenarioCreatePayload.from_dict(payload)
+        try:
+            scenario = portal_state.add_scenario(
+                project_id,
+                scenario_id=payload.id,
+                description=payload.description,
+                modifications=payload.modifications,
+            )
+        except (KeyError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return ScenarioCreatePayload(
+            id=scenario.id,
+            description=scenario.description,
+            modifications=scenario.modifications,
+        )
+
+    @app.put(
+        "/projects/{project_id}/scenarios/{scenario_id}",
+        response_model=ScenarioCreatePayload,
+    )
+    def update_scenario(
+        project_id: str, scenario_id: str, payload: ScenarioUpdatePayload | dict
+    ) -> ScenarioCreatePayload:
+        if isinstance(payload, dict):
+            payload = ScenarioUpdatePayload.from_dict(payload)
+        try:
+            scenario = portal_state.update_scenario(
+                project_id,
+                scenario_id,
+                description=payload.description,
+                modifications=payload.modifications,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return ScenarioCreatePayload(
+            id=scenario.id,
+            description=scenario.description,
+            modifications=scenario.modifications,
+        )
+
+    @app.delete("/projects/{project_id}/scenarios/{scenario_id}")
+    def delete_scenario(project_id: str, scenario_id: str) -> Response:
+        try:
+            portal_state.remove_scenario(project_id, scenario_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return Response(status_code=204, data=None)
+
+    @app.post("/projects/{project_id}/runs", response_model=RunResponse)
+    def create_run(project_id: str, payload: RunRequest | dict) -> RunResponse:
+        if isinstance(payload, dict):
+            payload = RunRequest.from_dict(payload)
+        try:
+            project = portal_state.get_project(project_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        scenario_ids = list(
+            payload.scenario_ids
+            or [scenario.id for scenario in project.model_config.scenarios]
+        )
+        run_record = portal_state.create_run(project_id, scenario_ids)
+
+        try:
+            result = _execute_workflow(project_id, project.model_config, payload, scenario_ids, portal_state)
+            portal_state.complete_run(run_record.id, result)
+        except Exception as exc:  # pragma: no cover - workflow errors bubble to client
+            portal_state.fail_run(run_record.id, str(exc))
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+        return RunResponse(**portal_state.get_run(run_record.id).to_dict())
+
+    @app.get("/projects/{project_id}/runs", response_model=RunList)
+    def list_project_runs(project_id: str) -> RunList:
+        try:
+            portal_state.get_project(project_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        runs = [RunResponse(**run.to_dict()) for run in portal_state.list_runs(project_id)]
+        return RunList(runs=runs)
+
+    @app.get("/runs/{run_id}", response_model=RunResponse)
+    def get_run(run_id: str) -> RunResponse:
+        try:
+            run = portal_state.get_run(run_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return RunResponse(**run.to_dict())
+
+    @app.get("/runs", response_model=RunList)
+    def list_runs() -> RunList:
+        runs = [RunResponse(**run.to_dict()) for run in portal_state.list_runs()]
+        return RunList(runs=runs)
+
+    @app.get("/runs/{run_id}/report")
+    def fetch_report(run_id: str) -> Dict[str, object]:
+        run = portal_state.get_run(run_id)
+        result = run.result
+        if result is None or result.report_path is None:
+            raise HTTPException(status_code=404, detail="Report not available")
+        report_path = Path(result.report_path)
+        if not report_path.exists():
+            raise HTTPException(status_code=404, detail="Report file missing")
+        return {"path": str(report_path), "content": report_path.read_text(encoding="utf-8")}
+
+    @app.get("/runs/{run_id}/figures")
+    def list_figures(run_id: str) -> Dict[str, Iterable[str]]:
+        run = portal_state.get_run(run_id)
+        result = run.result
+        if result is None or result.report_path is None:
+            return {"figures": []}
+        report_path = Path(result.report_path)
+        figures_dir = report_path.parent.parent / "figures"
+        if not figures_dir.exists():
+            return {"figures": []}
+        files = [str(path) for path in figures_dir.glob("*.png")]
+        return {"figures": files}
+
+    @app.get("/runs/{run_id}/summary")
+    def summarise_run(run_id: str) -> Dict[str, object]:
+        run = portal_state.get_run(run_id)
+        if run.result is None:
+            raise HTTPException(status_code=404, detail="Run result not available")
+        return summarise_workflow_result(run.result)
+
+    return app
+
+
+def _render_assistant_reply(intent: Dict[str, object], conversation_id: str) -> str:
+    action = intent.get("action", "general_chat")
+    if action == "run_scenarios":
+        scenarios = intent.get("parameters", {}).get("scenario_ids") or ["all configured scenarios"]
+        return f"Conversation {conversation_id}: 已识别到运行情景请求，目标情景：{', '.join(scenarios)}。"
+    if action == "create_scenario":
+        name = intent.get("parameters", {}).get("name", "新情景")
+        return f"Conversation {conversation_id}: 可以为你创建情景 {name}，请补充参数调整信息。"
+    if action == "list_scenarios":
+        return "我可以列出当前项目中的情景，请调用场景列表接口。"
+    if action == "summarise_results":
+        return "可根据最新运行结果生成报告摘要。"
+    return "已收到你的请求，如需运行模型请说明需要的情景或分析目标。"
+
+
+def _execute_workflow(
+    project_id: str,
+    config: ModelConfig,
+    payload: RunRequest,
+    scenario_ids: Iterable[str],
+    state: PortalState,
+) -> WorkflowResult:
+    config_copy = ModelConfig.from_dict(_remove_none(config.to_dict()))
+
+    dataset = None
+    try:
+        dataset = state.get_inputs(project_id)
+    except KeyError:
+        pass
+
+    forcing_payload = payload.forcing
+    observations_payload = payload.observations
+
+    if forcing_payload is not None:
+        existing_observations = dataset.observations if dataset else None
+        merged_observations = (
+            observations_payload
+            if observations_payload is not None
+            else existing_observations
+        )
+        dataset = state.set_inputs(project_id, forcing_payload, merged_observations)
+    else:
+        if dataset is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Forcing inputs are required. Upload them via /projects/{project_id}/inputs first.",
+            )
+        if observations_payload is not None:
+            dataset = state.set_inputs(project_id, dataset.forcing, observations_payload)
+
+    if dataset is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Project inputs are not configured",
+        )
+
+    forcing = _to_float_series(dataset.forcing)
+    observations = _to_optional_float_series(dataset.observations)
+
+    if payload.persist_outputs:
+        config_copy.io.results_directory.mkdir(parents=True, exist_ok=True)
+        if config_copy.io.figures_directory:
+            config_copy.io.figures_directory.mkdir(parents=True, exist_ok=True)
+        if config_copy.io.reports_directory:
+            config_copy.io.reports_directory.mkdir(parents=True, exist_ok=True)
+
+    return run_workflow(
+        config_copy,
+        forcing,
+        observations=observations,
+        scenario_ids=list(scenario_ids),
+        persist_outputs=payload.persist_outputs,
+        generate_report=payload.generate_report,
+    )
+
+
+def _to_float_series(data: Mapping[str, Iterable[float]]) -> Dict[str, List[float]]:
+    return {key: [float(value) for value in values] for key, values in data.items()}
+
+
+def _to_optional_float_series(
+    data: Optional[Mapping[str, Iterable[float]]]
+) -> Optional[Dict[str, List[float]]]:
+    if data is None:
+        return None
+    return _to_float_series(data)
+
+
+__all__ = ["create_app"]

--- a/hydrosis/portal/schemas.py
+++ b/hydrosis/portal/schemas.py
@@ -1,0 +1,257 @@
+"""Dataclass-based models exposed through the portal API."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+
+def _normalise_modifications(mods: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    normalised: Dict[str, Dict[str, Any]] = {}
+    for basin, values in mods.items():
+        if not isinstance(values, Mapping):
+            raise ValueError("each modification entry must be a mapping")
+        basin_key = str(basin)
+        basin_values: Dict[str, Any] = {}
+        for key, value in values.items():
+            if isinstance(value, (int, float)):
+                basin_values[str(key)] = float(value)
+            else:
+                basin_values[str(key)] = value
+        normalised[basin_key] = basin_values
+    return normalised
+
+
+@dataclass
+class ConversationMessageSchema:
+    role: str
+    content: str
+    intent: Optional[Dict[str, object]] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "ConversationMessageSchema":
+        return cls(role=str(data["role"]), content=str(data["content"]), intent=data.get("intent"))
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass
+class ConversationResponse:
+    reply: str
+    intent: Dict[str, object]
+    messages: List[ConversationMessageSchema] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "reply": self.reply,
+            "intent": self.intent,
+            "messages": [message.to_dict() for message in self.messages],
+        }
+
+
+@dataclass
+class ProjectConfigPayload:
+    model: Dict[str, object]
+    name: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "ProjectConfigPayload":
+        model = data.get("model")
+        if not isinstance(model, Mapping):
+            raise ValueError("model configuration must be a mapping")
+        name = data.get("name")
+        return cls(model=dict(model), name=str(name) if name is not None else None)
+
+
+@dataclass
+class ProjectSummary:
+    id: str
+    name: Optional[str]
+    scenarios: List[str]
+    evaluation: Optional[Dict[str, object]]
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass
+class ScenarioCreatePayload:
+    id: str
+    description: str
+    modifications: Mapping[str, Mapping[str, Any]]
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "ScenarioCreatePayload":
+        mods = data.get("modifications")
+        if not isinstance(mods, Mapping):
+            raise ValueError("modifications must be a mapping")
+        normalised = _normalise_modifications(mods)  # type: ignore[arg-type]
+        return cls(
+            id=str(data.get("id")),
+            description=str(data.get("description", "")),
+            modifications=normalised,
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "modifications": {basin: dict(values) for basin, values in self.modifications.items()},
+        }
+
+
+@dataclass
+class RunRequest:
+    forcing: Optional[Mapping[str, Sequence[float]]]
+    observations: Optional[Mapping[str, Sequence[float]]]
+    scenario_ids: Optional[Sequence[str]]
+    persist_outputs: bool
+    generate_report: bool
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "RunRequest":
+        forcing = data.get("forcing")
+        forcing_payload: Optional[Dict[str, List[float]]] = None
+        if forcing is not None:
+            if not isinstance(forcing, Mapping):
+                raise ValueError("forcing must be provided as a mapping of sequences")
+            forcing_payload = {str(key): list(value) for key, value in forcing.items()}
+        observations = data.get("observations")
+        observations_payload: Optional[Dict[str, List[float]]] = None
+        if observations is not None:
+            if not isinstance(observations, Mapping):
+                raise ValueError("observations must be provided as a mapping of sequences")
+            observations_payload = {
+                str(key): list(value) for key, value in observations.items()
+            }
+        scenario_ids = data.get("scenario_ids")
+        return cls(
+            forcing=forcing_payload,
+            observations=observations_payload,
+            scenario_ids=list(scenario_ids)
+            if isinstance(scenario_ids, Sequence)
+            and not isinstance(scenario_ids, (str, bytes))
+            else None,
+            persist_outputs=bool(data.get("persist_outputs", False)),
+            generate_report=bool(data.get("generate_report", False)),
+        )
+
+
+@dataclass
+class RunResponse:
+    id: str
+    project_id: str
+    scenario_ids: List[str]
+    status: str
+    error: Optional[str]
+    result: Optional[Dict[str, object]]
+    created_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass
+class ProjectInputsPayload:
+    forcing: Mapping[str, Sequence[float]]
+    observations: Optional[Mapping[str, Sequence[float]]] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "ProjectInputsPayload":
+        forcing = data.get("forcing")
+        if not isinstance(forcing, Mapping):
+            raise ValueError("forcing must be provided as a mapping of sequences")
+        observations = data.get("observations")
+        if observations is not None and not isinstance(observations, Mapping):
+            raise ValueError("observations must be a mapping when provided")
+        return cls(
+            forcing={str(key): list(value) for key, value in forcing.items()},
+            observations={
+                str(key): list(value) for key, value in observations.items()
+            }
+            if isinstance(observations, Mapping)
+            else None,
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "forcing": {key: list(values) for key, values in self.forcing.items()},
+            "observations": {
+                key: list(values) for key, values in (self.observations or {}).items()
+            }
+            or None,
+        }
+
+
+@dataclass
+class ProjectInputsResponse:
+    forcing: Mapping[str, Sequence[float]]
+    observations: Optional[Mapping[str, Sequence[float]]]
+    updated_at: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass
+class ScenarioList:
+    scenarios: List[ScenarioCreatePayload]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"scenarios": [scenario.to_dict() for scenario in self.scenarios]}
+
+
+@dataclass
+class ScenarioUpdatePayload:
+    description: Optional[str] = None
+    modifications: Optional[Mapping[str, Mapping[str, Any]]] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "ScenarioUpdatePayload":
+        description = data.get("description")
+        mods = data.get("modifications")
+        if mods is not None and not isinstance(mods, Mapping):
+            raise ValueError("modifications must be a mapping when provided")
+        return cls(
+            description=str(description) if description is not None else None,
+            modifications=_normalise_modifications(mods) if isinstance(mods, Mapping) else None,  # type: ignore[arg-type]
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "description": self.description,
+            "modifications": {basin: dict(values) for basin, values in (self.modifications or {}).items()},
+        }
+
+
+@dataclass
+class ProjectList:
+    projects: List[ProjectSummary]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"projects": [project.to_dict() for project in self.projects]}
+
+
+@dataclass
+class RunList:
+    runs: List[RunResponse]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"runs": [run.to_dict() for run in self.runs]}
+
+
+__all__ = [
+    "ConversationMessageSchema",
+    "ConversationResponse",
+    "ProjectConfigPayload",
+    "ProjectSummary",
+    "ProjectList",
+    "RunRequest",
+    "RunResponse",
+    "RunList",
+    "ScenarioCreatePayload",
+    "ScenarioList",
+    "ScenarioUpdatePayload",
+    "ProjectInputsPayload",
+    "ProjectInputsResponse",
+]

--- a/hydrosis/portal/state.py
+++ b/hydrosis/portal/state.py
@@ -1,0 +1,315 @@
+"""In-memory state container backing the HydroSIS portal API."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence
+import uuid
+
+from hydrosis.config import ModelConfig, ScenarioConfig
+from hydrosis.workflow import WorkflowResult, ScenarioRun, EvaluationOutcome
+
+
+@dataclass
+class ConversationMessage:
+    """Single utterance exchanged between the user and the assistant."""
+
+    role: str
+    content: str
+    intent: Optional[MutableMapping[str, object]] = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class Conversation:
+    """Minimal conversation log with linked intents."""
+
+    id: str
+    messages: List[ConversationMessage] = field(default_factory=list)
+
+    def add(self, message: ConversationMessage) -> None:
+        self.messages.append(message)
+
+
+@dataclass
+class Project:
+    """Project configuration stored within the portal."""
+
+    id: str
+    name: Optional[str]
+    model_config: ModelConfig
+
+    def to_summary(self) -> Dict[str, object]:
+        config_dict = self.model_config.to_dict()
+        return {
+            "id": self.id,
+            "name": self.name,
+            "scenarios": [scenario["id"] for scenario in config_dict.get("scenarios", [])],
+            "evaluation": config_dict.get("evaluation"),
+        }
+
+
+@dataclass
+class ProjectInputs:
+    """Persisted hydrological inputs associated with a project."""
+
+    project_id: str
+    forcing: Dict[str, List[float]]
+    observations: Optional[Dict[str, List[float]]]
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "project_id": self.project_id,
+            "forcing": {key: list(values) for key, values in self.forcing.items()},
+            "observations": {
+                key: list(values) for key, values in (self.observations or {}).items()
+            }
+            or None,
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+
+@dataclass
+class RunRecord:
+    """Execution record of a workflow invocation."""
+
+    id: str
+    project_id: str
+    scenario_ids: Sequence[str]
+    created_at: datetime
+    status: str
+    result: Optional[WorkflowResult] = None
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "project_id": self.project_id,
+            "scenario_ids": list(self.scenario_ids),
+            "created_at": self.created_at.isoformat(),
+            "status": self.status,
+            "error": self.error,
+            "result": serialize_workflow_result(self.result) if self.result else None,
+        }
+
+
+class PortalState:
+    """Centralised in-memory state for the API."""
+
+    def __init__(self) -> None:
+        self._conversations: Dict[str, Conversation] = {}
+        self._projects: Dict[str, Project] = {}
+        self._runs: Dict[str, RunRecord] = {}
+        self._inputs: Dict[str, ProjectInputs] = {}
+
+    # Conversation helpers -------------------------------------------------
+    def get_conversation(self, conversation_id: str) -> Conversation:
+        conversation = self._conversations.get(conversation_id)
+        if conversation is None:
+            conversation = Conversation(id=conversation_id)
+            self._conversations[conversation_id] = conversation
+        return conversation
+
+    # Project helpers ------------------------------------------------------
+    def upsert_project(
+        self, project_id: str, name: Optional[str], model_config: ModelConfig
+    ) -> Project:
+        project = Project(id=project_id, name=name, model_config=model_config)
+        self._projects[project_id] = project
+        return project
+
+    def get_project(self, project_id: str) -> Project:
+        if project_id not in self._projects:
+            raise KeyError(f"Project '{project_id}' is not registered")
+        return self._projects[project_id]
+
+    def list_projects(self) -> Sequence[Project]:
+        return list(self._projects.values())
+
+    def set_inputs(
+        self,
+        project_id: str,
+        forcing: Mapping[str, Sequence[float]],
+        observations: Optional[Mapping[str, Sequence[float]]] = None,
+    ) -> ProjectInputs:
+        project = self.get_project(project_id)
+        normalized_forcing = _normalise_series(forcing)
+        normalized_observations = (
+            _normalise_series(observations) if observations is not None else None
+        )
+        dataset = ProjectInputs(
+            project_id=project.id,
+            forcing=normalized_forcing,
+            observations=normalized_observations,
+        )
+        self._inputs[project_id] = dataset
+        return dataset
+
+    def get_inputs(self, project_id: str) -> Optional[ProjectInputs]:
+        if project_id not in self._projects:
+            raise KeyError(f"Project '{project_id}' is not registered")
+        return self._inputs.get(project_id)
+
+    def add_scenario(
+        self,
+        project_id: str,
+        scenario_id: str,
+        description: str,
+        modifications: Mapping[str, Mapping[str, Any]],
+    ) -> ScenarioConfig:
+        project = self.get_project(project_id)
+        if any(scenario.id == scenario_id for scenario in project.model_config.scenarios):
+            raise ValueError(f"Scenario '{scenario_id}' already exists")
+        scenario = ScenarioConfig(
+            id=scenario_id,
+            description=description,
+            modifications={
+                basin: dict(params)
+                for basin, params in modifications.items()
+            },
+        )
+        project.model_config.scenarios.append(scenario)
+        return scenario
+
+    def update_scenario(
+        self,
+        project_id: str,
+        scenario_id: str,
+        *,
+        description: Optional[str] = None,
+        modifications: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    ) -> ScenarioConfig:
+        project = self.get_project(project_id)
+        for index, scenario in enumerate(project.model_config.scenarios):
+            if scenario.id != scenario_id:
+                continue
+            if description is not None:
+                scenario.description = description
+            if modifications is not None:
+                scenario.modifications = {
+                    basin: dict(values)
+                    for basin, values in modifications.items()
+                }
+            project.model_config.scenarios[index] = scenario
+            return scenario
+        raise KeyError(f"Scenario '{scenario_id}' not found")
+
+    def remove_scenario(self, project_id: str, scenario_id: str) -> None:
+        project = self.get_project(project_id)
+        scenarios = project.model_config.scenarios
+        for index, scenario in enumerate(scenarios):
+            if scenario.id == scenario_id:
+                del scenarios[index]
+                return
+        raise KeyError(f"Scenario '{scenario_id}' not found")
+
+    def list_scenarios(self, project_id: str) -> Sequence[ScenarioConfig]:
+        project = self.get_project(project_id)
+        return list(project.model_config.scenarios)
+
+    # Run helpers ----------------------------------------------------------
+    def create_run(
+        self,
+        project_id: str,
+        scenario_ids: Sequence[str],
+    ) -> RunRecord:
+        run_id = uuid.uuid4().hex
+        record = RunRecord(
+            id=run_id,
+            project_id=project_id,
+            scenario_ids=list(scenario_ids),
+            created_at=datetime.now(timezone.utc),
+            status="pending",
+        )
+        self._runs[run_id] = record
+        return record
+
+    def complete_run(self, run_id: str, result: WorkflowResult) -> RunRecord:
+        record = self._runs[run_id]
+        record.status = "completed"
+        record.result = result
+        return record
+
+    def fail_run(self, run_id: str, error: str) -> RunRecord:
+        record = self._runs[run_id]
+        record.status = "failed"
+        record.error = error
+        return record
+
+    def get_run(self, run_id: str) -> RunRecord:
+        if run_id not in self._runs:
+            raise KeyError(f"Run '{run_id}' not found")
+        return self._runs[run_id]
+
+    def list_runs(self, project_id: Optional[str] = None) -> Sequence[RunRecord]:
+        runs = list(self._runs.values())
+        if project_id is None:
+            return sorted(runs, key=lambda record: record.created_at, reverse=True)
+        return sorted(
+            [run for run in runs if run.project_id == project_id],
+            key=lambda record: record.created_at,
+            reverse=True,
+        )
+
+
+# Serialisation utilities --------------------------------------------------
+
+def serialize_workflow_result(result: Optional[WorkflowResult]) -> Optional[Dict[str, object]]:
+    if result is None:
+        return None
+    return {
+        "baseline": serialize_scenario_run(result.baseline),
+        "scenarios": {
+            scenario_id: serialize_scenario_run(run)
+            for scenario_id, run in result.scenarios.items()
+        },
+        "overall_scores": [serialize_model_score(score) for score in result.overall_scores or []],
+        "evaluation_outcomes": [
+            serialize_evaluation_outcome(outcome)
+            for outcome in result.evaluation_outcomes
+        ],
+        "report_path": str(result.report_path) if result.report_path else None,
+    }
+
+
+def serialize_scenario_run(run: ScenarioRun) -> Dict[str, object]:
+    return {
+        "scenario_id": run.scenario_id,
+        "local": run.local,
+        "aggregated": run.aggregated,
+        "zone_discharge": run.zone_discharge,
+    }
+
+
+def serialize_model_score(score) -> Dict[str, object]:
+    return {
+        "model_id": score.model_id,
+        "per_subbasin": score.per_subbasin,
+        "aggregated": score.aggregated,
+    }
+
+
+def serialize_evaluation_outcome(outcome: EvaluationOutcome) -> Dict[str, object]:
+    return {
+        "plan": outcome.plan.to_dict(),
+        "scores": [serialize_model_score(score) for score in outcome.scores],
+        "ranking": [serialize_model_score(score) for score in outcome.ranking],
+        "ranking_metric": outcome.ranking_metric,
+    }
+
+
+
+def _normalise_series(data: Mapping[str, Sequence[float]]) -> Dict[str, List[float]]:
+    return {str(key): [float(value) for value in values] for key, values in data.items()}
+
+
+__all__ = [
+    "Conversation",
+    "ConversationMessage",
+    "PortalState",
+    "Project",
+    "RunRecord",
+    "ProjectInputs",
+    "serialize_workflow_result",
+]

--- a/hydrosis/portal/static/index.html
+++ b/hydrosis/portal/static/index.html
@@ -1,0 +1,504 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>HydroSIS Portal</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: "Segoe UI", Roboto, sans-serif;
+        margin: 0;
+        padding: 0;
+        background: #f5f7fb;
+        color: #1f2933;
+      }
+      header {
+        background: #1b5e20;
+        color: white;
+        padding: 1.5rem 2rem;
+      }
+      main {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 1.5rem;
+        padding: 2rem;
+      }
+      section {
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+        padding: 1.5rem;
+      }
+      h2 {
+        margin-top: 0;
+        font-size: 1.2rem;
+      }
+      textarea,
+      input,
+      button {
+        width: 100%;
+        padding: 0.6rem;
+        margin-top: 0.6rem;
+        border-radius: 8px;
+        border: 1px solid #cfd8dc;
+        font-size: 0.95rem;
+      }
+      button {
+        background: #1b5e20;
+        color: white;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #144618;
+      }
+      pre {
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 1rem;
+        border-radius: 8px;
+        overflow: auto;
+        max-height: 260px;
+      }
+      .messages {
+        max-height: 280px;
+        overflow-y: auto;
+        margin-top: 1rem;
+        border: 1px solid #e0e6ed;
+        border-radius: 8px;
+        padding: 0.8rem;
+        background: #f8fafc;
+      }
+      .message {
+        margin-bottom: 0.8rem;
+      }
+      .message strong {
+        display: block;
+        margin-bottom: 0.2rem;
+      }
+      .actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+        margin-top: 1rem;
+      }
+      .actions input,
+      .actions button {
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>HydroSIS 自然语言建模门户</h1>
+      <p>通过对话配置情景、触发模拟并查看报告。</p>
+    </header>
+    <main>
+      <section>
+        <h2>对话入口</h2>
+        <form id="chat-form">
+          <label for="chat-input">请输入自然语言指令：</label>
+          <textarea id="chat-input" rows="4" placeholder="例如：运行降雨增加 20% 的情景"></textarea>
+          <button type="submit">发送</button>
+        </form>
+        <div class="messages" id="messages"></div>
+      </section>
+      <section>
+        <h2>项目配置</h2>
+        <form id="config-form">
+          <label for="project-id">项目 ID</label>
+          <input id="project-id" value="demo" />
+          <label for="config-json">模型配置（JSON）</label>
+          <textarea id="config-json" rows="10" placeholder="粘贴 ModelConfig JSON"></textarea>
+          <button type="submit">保存配置</button>
+        </form>
+        <button type="button" id="refresh-projects">刷新项目列表</button>
+        <pre id="projects-list">尚无项目信息</pre>
+        <pre id="config-result">等待配置...</pre>
+      </section>
+      <section>
+        <h2>水文输入管理</h2>
+        <form id="inputs-form">
+          <label for="forcing-data">入流数据（JSON，键为子流域）</label>
+          <textarea id="forcing-data" rows="8" placeholder='{"S1": [0,10,20]}'></textarea>
+          <label for="observations-json">观测流量（JSON，可选）</label>
+          <textarea id="observations-json" rows="6" placeholder='{"S3": [0.5,0.8,0.2]}'></textarea>
+          <button type="submit">保存水文输入</button>
+        </form>
+        <div class="actions">
+          <button type="button" id="refresh-inputs">刷新输入信息</button>
+        </div>
+        <div id="inputs-feedback"></div>
+        <pre id="inputs-current">尚未配置输入</pre>
+      </section>
+      <section>
+        <h2>情景管理</h2>
+        <form id="scenario-create-form">
+          <label for="scenario-id">新情景 ID</label>
+          <input id="scenario-id" placeholder="scenario_id" />
+          <label for="scenario-description">描述</label>
+          <input id="scenario-description" placeholder="例如：降雨增加 20%" />
+          <label for="scenario-mods">参数调整（JSON）</label>
+          <textarea id="scenario-mods" rows="6" placeholder='{"S1": {"routing_model": "lag_long"}}'></textarea>
+          <button type="submit">创建情景</button>
+        </form>
+        <form id="scenario-update-form">
+          <label for="scenario-update-id">更新情景 ID</label>
+          <input id="scenario-update-id" placeholder="scenario_id" />
+          <label for="scenario-update-description">新的描述（可选）</label>
+          <input id="scenario-update-description" placeholder="输入新的描述" />
+          <label for="scenario-update-mods">参数调整（JSON，可选）</label>
+          <textarea id="scenario-update-mods" rows="4" placeholder='{"S2": {"runoff_model": "vic"}}'></textarea>
+          <button type="submit">更新情景</button>
+        </form>
+        <div class="actions">
+          <label for="scenario-delete-id">删除情景 ID</label>
+          <input id="scenario-delete-id" placeholder="scenario_id" />
+          <button type="button" id="scenario-delete">删除情景</button>
+          <button type="button" id="refresh-scenarios">刷新情景列表</button>
+        </div>
+        <div id="scenario-feedback"></div>
+        <pre id="scenario-list">尚无情景</pre>
+      </section>
+      <section>
+        <h2>触发模拟</h2>
+        <form id="run-form">
+          <label for="forcing-json">输入流量（JSON，键为子流域，值为数组）</label>
+          <textarea id="forcing-json" rows="8" placeholder='{"S1": [1,2,3], "S2": [0,1,0]}'></textarea>
+          <label for="scenarios">情景 ID（用逗号分隔，留空则运行全部）</label>
+          <input id="scenarios" placeholder="scenario_a,scenario_b" />
+          <label>
+            <input type="checkbox" id="persist" /> 持久化输出
+          </label>
+          <label>
+            <input type="checkbox" id="report" /> 生成报告
+          </label>
+          <button type="submit">执行</button>
+        </form>
+        <button type="button" id="refresh-runs">刷新运行记录</button>
+        <pre id="run-result">等待运行...</pre>
+        <pre id="run-history">尚无运行记录</pre>
+        <div class="actions">
+          <label for="summary-run-id">运行 ID（用于查看摘要）</label>
+          <input id="summary-run-id" placeholder="自动填入最近一次运行" />
+          <button type="button" id="fetch-summary">查看运行摘要</button>
+        </div>
+        <pre id="run-summary">尚未加载摘要</pre>
+      </section>
+    </main>
+    <script>
+      const messagesEl = document.getElementById("messages");
+      const projectInput = document.getElementById("project-id");
+      const scenarioFeedback = document.getElementById("scenario-feedback");
+      const inputsFeedback = document.getElementById("inputs-feedback");
+
+      function currentProjectId() {
+        return projectInput.value || "demo";
+      }
+
+      async function loadProjects() {
+        try {
+          const response = await fetch(`/projects`);
+          if (!response.ok) throw new Error(`请求失败: ${response.status}`);
+          const data = await response.json();
+          document.getElementById("projects-list").textContent = JSON.stringify(data.projects || [], null, 2);
+          await loadInputs();
+        } catch (err) {
+          document.getElementById("projects-list").textContent = `项目列表加载失败: ${err}`;
+        }
+      }
+
+      async function loadInputs() {
+        const projectId = currentProjectId();
+        try {
+          const response = await fetch(`/projects/${projectId}/inputs`);
+          if (response.status === 404) {
+            document.getElementById("inputs-current").textContent = "尚未配置输入";
+            return;
+          }
+          if (!response.ok) throw new Error(`请求失败: ${response.status}`);
+          const data = await response.json();
+          document.getElementById("inputs-current").textContent = JSON.stringify(data, null, 2);
+        } catch (err) {
+          document.getElementById("inputs-current").textContent = `输入加载失败: ${err}`;
+        }
+      }
+
+      async function loadScenarios() {
+        const projectId = currentProjectId();
+        try {
+          const response = await fetch(`/projects/${projectId}/scenarios`);
+          if (!response.ok) throw new Error(`请求失败: ${response.status}`);
+          const data = await response.json();
+          document.getElementById("scenario-list").textContent = JSON.stringify(data.scenarios || [], null, 2);
+        } catch (err) {
+          document.getElementById("scenario-list").textContent = `情景加载失败: ${err}`;
+        }
+      }
+
+      async function loadRuns() {
+        const projectId = currentProjectId();
+        try {
+          const response = await fetch(`/projects/${projectId}/runs`);
+          if (!response.ok) throw new Error(`请求失败: ${response.status}`);
+          const data = await response.json();
+          document.getElementById("run-history").textContent = JSON.stringify(data.runs || [], null, 2);
+          if (data.runs && data.runs.length && !document.getElementById("summary-run-id").value) {
+            document.getElementById("summary-run-id").value = data.runs[0].id;
+          }
+        } catch (err) {
+          document.getElementById("run-history").textContent = `运行记录加载失败: ${err}`;
+        }
+      }
+
+      document.getElementById("chat-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const content = document.getElementById("chat-input").value;
+        if (!content.trim()) return;
+        const response = await fetch(`/conversations/default/messages`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role: "user", content }),
+        });
+        const data = await response.json();
+        messagesEl.innerHTML = data.messages
+          .map(
+            (msg) => `
+              <div class="message">
+                <strong>${msg.role}</strong>
+                <div>${msg.content}</div>
+                ${msg.intent ? `<small>Intent: ${JSON.stringify(msg.intent)}</small>` : ""}
+              </div>
+            `
+          )
+          .join("\n");
+        document.getElementById("chat-input").value = "";
+      });
+
+      document.getElementById("config-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const projectId = currentProjectId();
+        const configText = document.getElementById("config-json").value;
+        try {
+          const model = JSON.parse(configText);
+          const response = await fetch(`/projects/${projectId}/config`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ model }),
+          });
+          const data = await response.json();
+          document.getElementById("config-result").textContent = JSON.stringify(data, null, 2);
+          await loadProjects();
+          await loadScenarios();
+        } catch (err) {
+          document.getElementById("config-result").textContent = `配置解析失败: ${err}`;
+        }
+      });
+
+      document.getElementById("refresh-projects").addEventListener("click", (event) => {
+        event.preventDefault();
+        loadProjects();
+      });
+
+      document.getElementById("inputs-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const projectId = currentProjectId();
+        const forcingText = document.getElementById("forcing-data").value.trim();
+        if (!forcingText) {
+          inputsFeedback.textContent = "请输入有效的入流数据 JSON";
+          return;
+        }
+        let forcing;
+        try {
+          forcing = JSON.parse(forcingText);
+        } catch (err) {
+          inputsFeedback.textContent = `入流数据解析失败: ${err}`;
+          return;
+        }
+        const observationsText = document.getElementById("observations-json").value.trim();
+        let observations;
+        if (observationsText) {
+          try {
+            observations = JSON.parse(observationsText);
+          } catch (err) {
+            inputsFeedback.textContent = `观测数据解析失败: ${err}`;
+            return;
+          }
+        }
+        const payload = { forcing };
+        if (observations !== undefined) {
+          payload.observations = observations;
+        }
+        const response = await fetch(`/projects/${projectId}/inputs`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          inputsFeedback.textContent = `保存失败: ${await response.text()}`;
+          return;
+        }
+        inputsFeedback.textContent = "输入已更新";
+        loadInputs();
+      });
+
+      document.getElementById("refresh-inputs").addEventListener("click", (event) => {
+        event.preventDefault();
+        loadInputs();
+      });
+
+      document.getElementById("scenario-create-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const projectId = currentProjectId();
+        let modifications;
+        try {
+          modifications = JSON.parse(document.getElementById("scenario-mods").value || "{}");
+        } catch (err) {
+          scenarioFeedback.textContent = `情景参数解析失败: ${err}`;
+          return;
+        }
+        const payload = {
+          id: document.getElementById("scenario-id").value,
+          description: document.getElementById("scenario-description").value,
+          modifications,
+        };
+        const response = await fetch(`/projects/${projectId}/scenarios`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          scenarioFeedback.textContent = `创建失败: ${await response.text()}`;
+          return;
+        }
+        scenarioFeedback.textContent = "情景创建成功";
+        document.getElementById("scenario-create-form").reset();
+        loadScenarios();
+      });
+
+      document.getElementById("scenario-update-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const projectId = currentProjectId();
+        const scenarioId = document.getElementById("scenario-update-id").value;
+        let modifications;
+        const modsText = document.getElementById("scenario-update-mods").value;
+        if (modsText.trim()) {
+          try {
+            modifications = JSON.parse(modsText);
+          } catch (err) {
+            scenarioFeedback.textContent = `更新参数解析失败: ${err}`;
+            return;
+          }
+        }
+        const payload = {
+          description: document.getElementById("scenario-update-description").value || undefined,
+          modifications,
+        };
+        const response = await fetch(`/projects/${projectId}/scenarios/${scenarioId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          scenarioFeedback.textContent = `更新失败: ${await response.text()}`;
+          return;
+        }
+        scenarioFeedback.textContent = "情景更新成功";
+        document.getElementById("scenario-update-form").reset();
+        loadScenarios();
+      });
+
+      document.getElementById("scenario-delete").addEventListener("click", async (event) => {
+        event.preventDefault();
+        const projectId = currentProjectId();
+        const scenarioId = document.getElementById("scenario-delete-id").value;
+        if (!scenarioId) {
+          scenarioFeedback.textContent = "请先填写情景 ID";
+          return;
+        }
+        const response = await fetch(`/projects/${projectId}/scenarios/${scenarioId}`, {
+          method: "DELETE",
+        });
+        if (!response.ok) {
+          scenarioFeedback.textContent = `删除失败: ${await response.text()}`;
+          return;
+        }
+        scenarioFeedback.textContent = "情景已删除";
+        document.getElementById("scenario-delete-id").value = "";
+        loadScenarios();
+      });
+
+      document.getElementById("refresh-scenarios").addEventListener("click", (event) => {
+        event.preventDefault();
+        loadScenarios();
+      });
+
+      document.getElementById("run-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const projectId = currentProjectId();
+        const forcingText = document.getElementById("forcing-json").value.trim();
+        let forcing;
+        if (forcingText) {
+          try {
+            forcing = JSON.parse(forcingText);
+          } catch (err) {
+            document.getElementById("run-result").textContent = `降雨数据解析失败: ${err}`;
+            return;
+          }
+        }
+        const scenarioText = document.getElementById("scenarios").value;
+        const scenario_ids = scenarioText
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean);
+        const body = {
+          scenario_ids,
+          persist_outputs: document.getElementById("persist").checked,
+          generate_report: document.getElementById("report").checked,
+        };
+        if (forcing !== undefined) {
+          body.forcing = forcing;
+        }
+        const response = await fetch(`/projects/${projectId}/runs`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const data = await response.json();
+        document.getElementById("run-result").textContent = JSON.stringify(data, null, 2);
+        if (data.id) {
+          document.getElementById("summary-run-id").value = data.id;
+          await loadRunSummary(data.id);
+        }
+        loadRuns();
+      });
+
+      document.getElementById("refresh-runs").addEventListener("click", (event) => {
+        event.preventDefault();
+        loadRuns();
+      });
+
+      async function loadRunSummary(runId) {
+        if (!runId) return;
+        try {
+          const response = await fetch(`/runs/${runId}/summary`);
+          if (!response.ok) throw new Error(`请求失败: ${response.status}`);
+          const data = await response.json();
+          document.getElementById("run-summary").textContent = JSON.stringify(data, null, 2);
+        } catch (err) {
+          document.getElementById("run-summary").textContent = `摘要获取失败: ${err}`;
+        }
+      }
+
+      document.getElementById("fetch-summary").addEventListener("click", (event) => {
+        event.preventDefault();
+        const runId = document.getElementById("summary-run-id").value;
+        loadRunSummary(runId);
+      });
+
+      loadProjects();
+      loadScenarios();
+      loadInputs();
+      loadRuns();
+    </script>
+  </body>
+</html>

--- a/tests/test_portal_api.py
+++ b/tests/test_portal_api.py
@@ -1,0 +1,235 @@
+"""Integration tests for the HydroSIS portal FastAPI application."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi.testclient import TestClient
+
+from hydrosis import HydroSISModel
+from hydrosis.config import (
+    ComparisonPlanConfig,
+    EvaluationConfig,
+    IOConfig,
+    ModelConfig,
+    ScenarioConfig,
+)
+from hydrosis.delineation.dem_delineator import DelineationConfig
+from hydrosis.parameters.zone import ParameterZoneConfig
+from hydrosis.portal import create_app
+from hydrosis.runoff.base import RunoffModelConfig
+from hydrosis.routing.base import RoutingModelConfig
+
+
+def _build_portal_config(results_directory: Path) -> ModelConfig:
+    delineation = DelineationConfig(
+        dem_path=Path("dem.tif"),
+        pour_points_path=Path("pour_points.geojson"),
+        precomputed_subbasins=[
+            {"id": "S1", "area_km2": 1.0, "downstream": "S3", "parameters": {}},
+            {"id": "S2", "area_km2": 1.0, "downstream": "S3", "parameters": {}},
+            {"id": "S3", "area_km2": 1.0, "downstream": None, "parameters": {}},
+        ],
+    )
+
+    runoff_models = [
+        RunoffModelConfig(
+            id="curve",
+            model_type="scs_curve_number",
+            parameters={"curve_number": 75, "initial_abstraction_ratio": 0.2},
+        ),
+        RunoffModelConfig(
+            id="reservoir",
+            model_type="linear_reservoir",
+            parameters={"recession": 0.85, "conversion": 1.0},
+        ),
+    ]
+
+    routing_models = [
+        RoutingModelConfig(
+            id="lag_short",
+            model_type="lag",
+            parameters={"lag_steps": 1},
+        ),
+        RoutingModelConfig(
+            id="lag_long",
+            model_type="lag",
+            parameters={"lag_steps": 2},
+        ),
+    ]
+
+    parameter_zones = [
+        ParameterZoneConfig(
+            id="Z1",
+            description="Headwater gauge",
+            control_points=["S1"],
+            parameters={"runoff_model": "curve", "routing_model": "lag_short"},
+        ),
+        ParameterZoneConfig(
+            id="Z2",
+            description="Outlet station",
+            control_points=["S3"],
+            parameters={"runoff_model": "reservoir", "routing_model": "lag_short"},
+        ),
+    ]
+
+    io_config = IOConfig(
+        precipitation=Path("data/forcing/precipitation.csv"),
+        results_directory=results_directory,
+        figures_directory=results_directory / "figures",
+        reports_directory=results_directory / "reports",
+    )
+
+    scenarios = [
+        ScenarioConfig(
+            id="alternate_routing",
+            description="Slow down routing through the middle catchment",
+            modifications={"S2": {"routing_model": "lag_long"}},
+        )
+    ]
+
+    evaluation = EvaluationConfig(
+        metrics=["rmse", "nse"],
+        comparisons=[
+            ComparisonPlanConfig(
+                id="baseline_vs_scenario",
+                description="Compare baseline and scenario accuracy at the outlet",
+                models=["baseline", "alternate_routing"],
+                reference="observed",
+                subbasins=["S3"],
+                ranking_metric="rmse",
+            )
+        ],
+    )
+
+    return ModelConfig(
+        delineation=delineation,
+        runoff_models=runoff_models,
+        routing_models=routing_models,
+        parameter_zones=parameter_zones,
+        io=io_config,
+        scenarios=scenarios,
+        evaluation=evaluation,
+    )
+
+
+def test_portal_end_to_end_workflow() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    forcing: Dict[str, List[float]] = {
+        "S1": [0.0, 10.0, 30.0, 0.0],
+        "S2": [5.0, 5.0, 5.0, 5.0],
+        "S3": [0.0, 0.0, 0.0, 0.0],
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = _build_portal_config(Path(tmpdir) / "results")
+        config_payload = config.to_dict()
+
+        response = client.post(
+            "/projects/demo/config",
+            json={"model": config_payload, "name": "Demo"},
+        )
+        assert response.status_code == 200
+        project_summary = response.json()
+        assert project_summary["scenarios"] == ["alternate_routing"]
+
+        projects_response = client.get("/projects")
+        assert projects_response.status_code == 200
+        projects = projects_response.json()["projects"]
+        assert any(project["id"] == "demo" for project in projects)
+
+        model = HydroSISModel.from_config(config)
+        baseline_local = model.run(forcing)
+        observations = {
+            basin: list(values) for basin, values in model.accumulate_discharge(baseline_local).items()
+        }
+
+        inputs_response = client.post(
+            "/projects/demo/inputs",
+            json={"forcing": forcing, "observations": observations},
+        )
+        assert inputs_response.status_code == 200
+        inputs_payload = inputs_response.json()
+        assert inputs_payload["forcing"]["S1"] == forcing["S1"]
+        assert "updated_at" in inputs_payload
+
+        inputs_get = client.get("/projects/demo/inputs")
+        assert inputs_get.status_code == 200
+        assert inputs_get.json()["observations"]["S1"] == observations["S1"]
+
+        scenario_create = client.post(
+            "/projects/demo/scenarios",
+            json={
+                "id": "higher_inflow",
+                "description": "Increase precipitation by 10%",
+                "modifications": {"S1": {"precipitation_multiplier": 1.1}},
+            },
+        )
+        assert scenario_create.status_code == 200
+        assert scenario_create.json()["id"] == "higher_inflow"
+
+        scenario_update = client.put(
+            "/projects/demo/scenarios/alternate_routing",
+            json={"description": "Updated description"},
+        )
+        assert scenario_update.status_code == 200
+        assert scenario_update.json()["description"] == "Updated description"
+
+        scenarios_response = client.get("/projects/demo/scenarios")
+        assert scenarios_response.status_code == 200
+        scenario_ids = [item["id"] for item in scenarios_response.json()["scenarios"]]
+        assert set(scenario_ids) == {"alternate_routing", "higher_inflow"}
+
+        delete_response = client.delete("/projects/demo/scenarios/higher_inflow")
+        assert delete_response.status_code == 204
+        scenarios_after_delete = client.get("/projects/demo/scenarios").json()["scenarios"]
+        assert all(item["id"] != "higher_inflow" for item in scenarios_after_delete)
+
+        chat_response = client.post(
+            "/conversations/default/messages",
+            json={"role": "user", "content": "请运行 scenario alternate_routing"},
+        )
+        assert chat_response.status_code == 200
+        assert chat_response.json()["intent"]["action"] == "run_scenarios"
+
+        run_response = client.post(
+            "/projects/demo/runs",
+            json={
+                "scenario_ids": ["alternate_routing"],
+                "persist_outputs": False,
+                "generate_report": False,
+            },
+        )
+        assert run_response.status_code == 200, run_response.text
+        payload = run_response.json()
+        assert payload["status"] == "completed"
+        assert payload["result"]
+        assert "baseline" in payload["result"]
+        assert payload["result"]["overall_scores"]
+
+        run_id = payload["id"]
+
+        summary_response = client.get(f"/runs/{run_id}/summary")
+        assert summary_response.status_code == 200
+        summary = summary_response.json()
+        assert summary["baseline"]["scenario_id"] == "baseline"
+        assert "narrative" in summary and summary["narrative"]
+        assert "alternate_routing" in summary["scenarios"]
+        alt_summary = summary["scenarios"]["alternate_routing"]
+        assert "aggregated" in alt_summary and "S3" in alt_summary["aggregated"]
+        assert "delta_vs_baseline" in alt_summary
+
+        project_runs = client.get("/projects/demo/runs")
+        assert project_runs.status_code == 200
+        assert any(run["id"] == run_id for run in project_runs.json()["runs"])
+
+        all_runs = client.get("/runs")
+        assert all_runs.status_code == 200
+        assert any(run["id"] == run_id for run in all_runs.json()["runs"])
+
+        get_response = client.get(f"/runs/{run_id}")
+        assert get_response.status_code == 200
+        assert get_response.json()["id"] == run_id


### PR DESCRIPTION
## Summary
- add project input persistence APIs and reuse logic so runs can omit forcing data once uploaded
- extend the portal state, schemas, and UI to surface the stored forcing/observation datasets
- update documentation and integration tests to cover the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5f9300e483308bb90ecd076acbc3