### PR TITLE
Add asynchronous run execution with streaming progress updates

### DIFF
--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable, Iterator
 
 
 @dataclass
@@ -14,4 +15,15 @@ class HTMLResponse:
         yield self.content
 
 
-__all__ = ["HTMLResponse"]
+@dataclass
+class StreamingResponse:
+    """Very small streaming response shim used for server-sent events in tests."""
+
+    body: Iterable[str]
+    media_type: str = "text/plain"
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self.body
+
+
+__all__ = ["HTMLResponse", "StreamingResponse"]

--- a/hydrosis/portal/executor.py
+++ b/hydrosis/portal/executor.py
@@ -1,0 +1,329 @@
+"""Background execution utilities for workflow runs."""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import threading
+from queue import Queue
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from hydrosis.config import ModelConfig
+from hydrosis.workflow import WorkflowResult
+
+from .analytics import summarise_workflow_result
+from .schemas import RunRequest
+from .state import PortalState
+
+ProgressCallback = Callable[[str, Mapping[str, object]], None]
+WorkflowRunner = Callable[
+    [
+        str,
+        ModelConfig,
+        RunRequest,
+        Iterable[str],
+        PortalState,
+        Optional[ProgressCallback],
+    ],
+    WorkflowResult,
+]
+
+
+@dataclass
+class ProgressTracker:
+    """Track high-level progress milestones for a run."""
+
+    scenario_total: int
+    baseline_completed: bool = False
+    scenarios_completed: int = 0
+    evaluation_enabled: bool = False
+    evaluation_completed: bool = False
+
+    @property
+    def total_segments(self) -> int:
+        evaluation_segments = 1 if self.evaluation_enabled else 0
+        return max(1, 1 + self.scenario_total + evaluation_segments)
+
+    @property
+    def completed_segments(self) -> int:
+        completed = 1 if self.baseline_completed else 0
+        completed += self.scenarios_completed
+        if self.evaluation_enabled and self.evaluation_completed:
+            completed += 1
+        return min(completed, self.total_segments)
+
+    def percent_complete(self) -> int:
+        if self.total_segments == 0:
+            return 100
+        return int((self.completed_segments / self.total_segments) * 100)
+
+    def mark_baseline_complete(self) -> None:
+        self.baseline_completed = True
+
+    def mark_scenario_complete(self) -> None:
+        self.scenarios_completed = min(self.scenarios_completed + 1, self.scenario_total)
+
+    def enable_evaluation(self) -> None:
+        self.evaluation_enabled = True
+
+    def mark_evaluation_complete(self) -> None:
+        if self.evaluation_enabled:
+            self.evaluation_completed = True
+
+
+@dataclass
+class RunProgressEvent:
+    """Structured payload emitted to subscribers tracking a workflow run."""
+
+    run_id: str
+    stage: str
+    status: str
+    timestamp: str
+    percent: int
+    message: Optional[str] = None
+    phase: Optional[str] = None
+    progress: Mapping[str, int] = field(default_factory=dict)
+    details: Mapping[str, object] = field(default_factory=dict)
+    summary: Optional[Mapping[str, object]] = None
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "run_id": self.run_id,
+            "stage": self.stage,
+            "status": self.status,
+            "timestamp": self.timestamp,
+            "percent": self.percent,
+        }
+        if self.message is not None:
+            payload["message"] = self.message
+        if self.phase is not None:
+            payload["phase"] = self.phase
+        if self.progress:
+            payload["progress"] = dict(self.progress)
+        if self.details:
+            payload["details"] = dict(self.details)
+        if self.summary is not None:
+            payload["summary"] = dict(self.summary)
+        if self.error is not None:
+            payload["error"] = self.error
+        return payload
+
+
+class RunEventBroker:
+    """Multiplexes progress events to multiple subscribers using thread-safe queues."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, List[Queue]] = {}
+        self._latest: Dict[str, Dict[str, object]] = {}
+        self._lock = threading.Lock()
+
+    def subscribe(self, run_id: str) -> Queue:
+        queue: Queue = Queue()
+        with self._lock:
+            self._subscribers.setdefault(run_id, []).append(queue)
+        return queue
+
+    def unsubscribe(self, run_id: str, queue: Queue) -> None:
+        with self._lock:
+            subscribers = self._subscribers.get(run_id)
+            if not subscribers:
+                return
+            try:
+                subscribers.remove(queue)
+            except ValueError:
+                return
+            if not subscribers:
+                self._subscribers.pop(run_id, None)
+
+    def latest(self, run_id: str) -> Optional[Dict[str, object]]:
+        with self._lock:
+            payload = self._latest.get(run_id)
+            return dict(payload) if payload is not None else None
+
+    def publish(self, run_id: str, event: RunProgressEvent) -> None:
+        payload = event.to_dict()
+        with self._lock:
+            self._latest[run_id] = dict(payload)
+            subscribers = list(self._subscribers.get(run_id, []))
+        for queue in subscribers:
+            queue.put(dict(payload))
+
+
+class RunExecutor:
+    """Submit workflow runs to a background worker and emit progress events."""
+
+    def __init__(
+        self,
+        state: PortalState,
+        broker: RunEventBroker,
+        workflow_runner: WorkflowRunner,
+        max_workers: int = 2,
+    ) -> None:
+        self._state = state
+        self._broker = broker
+        self._workflow_runner = workflow_runner
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+
+    def _build_message(self, stage: str, payload: Mapping[str, object]) -> str:
+        phase = payload.get("phase")
+        if stage == "baseline":
+            return "基准情景模拟完成" if phase == "complete" else "开始基准情景模拟"
+        if stage == "scenario":
+            scenario_id = payload.get("scenario_id")
+            index = payload.get("index")
+            total = payload.get("total")
+            label = f"情景 {scenario_id}" if scenario_id else "情景"
+            if phase == "complete":
+                return f"{label} 完成 ({index}/{total})"
+            return f"开始 {label} ({index}/{total})"
+        if stage == "evaluation":
+            return "评估阶段完成" if phase == "complete" else "开始评估阶段"
+        if stage == "evaluation_plan":
+            plan_id = payload.get("plan_id")
+            label = f"评估方案 {plan_id}" if plan_id else "评估方案"
+            return f"{label} {payload.get('phase')} ({payload.get('index')}/{payload.get('total')})"
+        if stage == "persistence":
+            return "输出已写入结果目录" if phase == "complete" else "正在写入输出文件"
+        if stage == "report":
+            return "报告生成完成" if phase == "complete" else "正在生成评估报告"
+        if stage == "workflow":
+            return "工作流执行完成" if phase == "complete" else "准备执行工作流"
+        return f"{stage} 阶段更新"
+
+    def _emit_progress(
+        self,
+        run_id: str,
+        stage: str,
+        tracker: ProgressTracker,
+        payload: Mapping[str, object],
+    ) -> None:
+        phase = payload.get("phase")
+        if stage == "scenario" and "total" in payload:
+            tracker.scenario_total = max(int(payload.get("total", tracker.scenario_total)), 0)
+        if stage == "evaluation" and phase == "start":
+            tracker.enable_evaluation()
+        if stage == "baseline" and phase == "complete":
+            tracker.mark_baseline_complete()
+        if stage == "scenario" and phase == "complete":
+            tracker.mark_scenario_complete()
+        if stage == "evaluation" and phase == "complete":
+            tracker.mark_evaluation_complete()
+
+        message = str(payload.get("message")) if "message" in payload else self._build_message(stage, payload)
+        event = RunProgressEvent(
+            run_id=run_id,
+            stage=stage,
+            status="running",
+            phase=phase if isinstance(phase, str) else None,
+            message=message,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            percent=tracker.percent_complete(),
+            progress={
+                "completed": tracker.completed_segments,
+                "total": tracker.total_segments,
+                "scenarios_completed": tracker.scenarios_completed,
+                "scenario_total": tracker.scenario_total,
+            },
+            details={key: value for key, value in payload.items() if key not in {"message"}},
+        )
+        self._broker.publish(run_id, event)
+
+    def submit(
+        self,
+        run_id: str,
+        project_id: str,
+        config: ModelConfig,
+        payload: RunRequest,
+        scenario_ids: Sequence[str],
+    ) -> None:
+        tracker = ProgressTracker(scenario_total=len(list(scenario_ids)))
+        queued_event = RunProgressEvent(
+            run_id=run_id,
+            stage="queue",
+            status="queued",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            percent=0,
+            message="运行已加入队列等待执行",
+            progress={
+                "completed": 0,
+                "total": tracker.total_segments,
+                "scenarios_completed": 0,
+                "scenario_total": tracker.scenario_total,
+            },
+        )
+        self._broker.publish(run_id, queued_event)
+
+        def progress_callback(stage: str, progress_payload: Mapping[str, object]) -> None:
+            self._emit_progress(run_id, stage, tracker, progress_payload)
+
+        def task() -> None:
+            self._state.start_run(run_id)
+            start_event = RunProgressEvent(
+                run_id=run_id,
+                stage="workflow",
+                status="running",
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                percent=tracker.percent_complete(),
+                message="工作流执行已开始",
+                progress={
+                    "completed": tracker.completed_segments,
+                    "total": tracker.total_segments,
+                    "scenarios_completed": tracker.scenarios_completed,
+                    "scenario_total": tracker.scenario_total,
+                },
+            )
+            self._broker.publish(run_id, start_event)
+            try:
+                result = self._workflow_runner(
+                    project_id,
+                    config,
+                    payload,
+                    scenario_ids,
+                    self._state,
+                    progress_callback,
+                )
+                tracker.mark_baseline_complete()
+                tracker.scenarios_completed = tracker.scenario_total
+                tracker.mark_evaluation_complete()
+                summary = summarise_workflow_result(result)
+                self._state.complete_run(run_id, result)
+                completion_event = RunProgressEvent(
+                    run_id=run_id,
+                    stage="workflow",
+                    status="completed",
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    percent=100,
+                    message="运行完成，结果已保存",
+                    progress={
+                        "completed": tracker.total_segments,
+                        "total": tracker.total_segments,
+                        "scenarios_completed": tracker.scenario_total,
+                        "scenario_total": tracker.scenario_total,
+                    },
+                    summary=summary if summary is not None else None,
+                )
+                self._broker.publish(run_id, completion_event)
+            except Exception as exc:  # pragma: no cover - runtime failures are reported to clients
+                self._state.fail_run(run_id, str(exc))
+                failure_event = RunProgressEvent(
+                    run_id=run_id,
+                    stage="workflow",
+                    status="failed",
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    percent=tracker.percent_complete(),
+                    message="运行失败，请查看错误信息",
+                    progress={
+                        "completed": tracker.completed_segments,
+                        "total": tracker.total_segments,
+                        "scenarios_completed": tracker.scenarios_completed,
+                        "scenario_total": tracker.scenario_total,
+                    },
+                    error=str(exc),
+                )
+                self._broker.publish(run_id, failure_event)
+
+        self._executor.submit(task)
+
+
+__all__ = ["RunExecutor", "RunEventBroker", "RunProgressEvent", "ProgressTracker"]

--- a/hydrosis/portal/static/index.html
+++ b/hydrosis/portal/static/index.html
@@ -85,6 +85,43 @@
       .actions button {
         width: 100%;
       }
+      .progress-container {
+        margin-top: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+      }
+      .progress-bar-wrapper {
+        width: 100%;
+        background: #e1e5ee;
+        border-radius: 999px;
+        overflow: hidden;
+        height: 16px;
+      }
+      .progress-bar-fill {
+        height: 100%;
+        width: 0%;
+        background: linear-gradient(90deg, #1b5e20, #4caf50);
+        color: white;
+        font-size: 0.75rem;
+        text-align: center;
+        line-height: 16px;
+        transition: width 0.3s ease;
+      }
+      .progress-status {
+        font-size: 0.9rem;
+        color: #0f172a;
+      }
+      .progress-log {
+        background: #f1f5f9;
+        border-radius: 8px;
+        padding: 0.75rem;
+        max-height: 200px;
+        overflow-y: auto;
+        font-family: "Fira Code", monospace;
+        font-size: 0.85rem;
+        white-space: pre-wrap;
+      }
     </style>
   </head>
   <body>
@@ -173,14 +210,21 @@
           <label>
             <input type="checkbox" id="report" /> 生成报告
           </label>
-          <button type="submit">执行</button>
-        </form>
-        <button type="button" id="refresh-runs">刷新运行记录</button>
-        <pre id="run-result">等待运行...</pre>
-        <pre id="run-history">尚无运行记录</pre>
-        <div class="actions">
-          <label for="summary-run-id">运行 ID（用于查看摘要）</label>
-          <input id="summary-run-id" placeholder="自动填入最近一次运行" />
+        <button type="submit">执行</button>
+      </form>
+      <button type="button" id="refresh-runs">刷新运行记录</button>
+      <pre id="run-result">等待运行...</pre>
+      <div class="progress-container">
+        <div class="progress-bar-wrapper">
+          <div id="run-progress-bar" class="progress-bar-fill">0%</div>
+        </div>
+        <div id="run-progress-status" class="progress-status">尚未开始实时进度</div>
+        <div id="run-progress-log" class="progress-log">尚未开始实时进度</div>
+      </div>
+      <pre id="run-history">尚无运行记录</pre>
+      <div class="actions">
+        <label for="summary-run-id">运行 ID（用于查看摘要）</label>
+        <input id="summary-run-id" placeholder="自动填入最近一次运行" />
           <button type="button" id="fetch-summary">查看运行摘要</button>
           <button type="button" id="fetch-timeseries">查看时序数据</button>
           <button type="button" id="fetch-evaluation">查看评估结果</button>
@@ -196,6 +240,81 @@
       const overviewEl = document.getElementById("project-overview");
       const scenarioFeedback = document.getElementById("scenario-feedback");
       const inputsFeedback = document.getElementById("inputs-feedback");
+      const progressStatusEl = document.getElementById("run-progress-status");
+      const progressBarEl = document.getElementById("run-progress-bar");
+      const progressLogEl = document.getElementById("run-progress-log");
+      let runEventSource = null;
+
+      function resetProgressDisplay() {
+        progressBarEl.style.width = "0%";
+        progressBarEl.textContent = "0%";
+        progressStatusEl.textContent = "尚未开始实时进度";
+        progressLogEl.textContent = "尚未开始实时进度";
+      }
+
+      function appendProgressLog(entry) {
+        const timestamp = entry.timestamp || new Date().toISOString();
+        const message = entry.message || `${entry.stage || "阶段"} ${entry.status || "更新"}`;
+        const line = `[${timestamp}] ${message}`;
+        if (!progressLogEl.textContent || progressLogEl.textContent === "尚未开始实时进度") {
+          progressLogEl.textContent = line;
+          return;
+        }
+        progressLogEl.textContent = `${line}\n${progressLogEl.textContent}`;
+      }
+
+      function updateProgressDisplay(event) {
+        if (typeof event.percent === "number") {
+          progressBarEl.style.width = `${event.percent}%`;
+          progressBarEl.textContent = `${event.percent}%`;
+        }
+        if (event.message) {
+          progressStatusEl.textContent = event.message;
+        }
+        appendProgressLog(event);
+      }
+
+      function closeRunStream() {
+        if (runEventSource) {
+          runEventSource.close();
+          runEventSource = null;
+        }
+      }
+
+      function openRunStream(runId) {
+        if (typeof EventSource === "undefined") {
+          progressStatusEl.textContent = "浏览器不支持实时事件流";
+          return;
+        }
+        closeRunStream();
+        progressBarEl.style.width = "0%";
+        progressBarEl.textContent = "0%";
+        progressLogEl.textContent = "";
+        progressStatusEl.textContent = "运行已排队，等待开始";
+        runEventSource = new EventSource(`/runs/${runId}/stream`);
+        runEventSource.onmessage = (event) => {
+          try {
+            const payload = JSON.parse(event.data || "{}");
+            updateProgressDisplay(payload);
+            if (payload.status === "completed") {
+              closeRunStream();
+              loadRuns();
+              loadOverview();
+              loadRunSummary(runId);
+              loadRunTimeseries(runId);
+              loadRunEvaluation(runId);
+            } else if (payload.status === "failed") {
+              closeRunStream();
+            }
+          } catch (err) {
+            appendProgressLog({ message: `解析进度事件失败: ${err}` });
+          }
+        };
+        runEventSource.onerror = () => {
+          appendProgressLog({ message: "进度流连接已断开" });
+          closeRunStream();
+        };
+      }
 
       function currentProjectId() {
         return projectInput.value || "demo";
@@ -500,9 +619,7 @@
         document.getElementById("run-result").textContent = JSON.stringify(data, null, 2);
         if (data.id) {
           document.getElementById("summary-run-id").value = data.id;
-          await loadRunSummary(data.id);
-          await loadRunTimeseries(data.id);
-          await loadRunEvaluation(data.id);
+          openRunStream(data.id);
         }
         loadRuns();
         loadOverview();
@@ -569,6 +686,7 @@
         await loadRunEvaluation(runId);
       });
 
+      resetProgressDisplay();
       loadProjects();
       loadScenarios();
       loadInputs();


### PR DESCRIPTION
## Summary
- add a background RunExecutor that queues workflow runs, publishes structured progress events, and updates run state safely
- expose a `/runs/{run_id}/stream` server-sent events endpoint and extend the portal frontend to display live progress updates and results once complete
- enrich `run_workflow` with progress callbacks and enhance the FastAPI shim to support streaming responses required by the new endpoint

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68cde2fe2c5883309b4d8b4073750c45