### PR TITLE
feat: integrate Qwen-powered intent parsing into portal

### DIFF
--- a/hydrosis/portal/llm.py
+++ b/hydrosis/portal/llm.py
@@ -1,19 +1,49 @@
 """Lightweight natural language interpreter used by the portal."""
 from __future__ import annotations
 
+import json
 import re
-from typing import Dict, List
+from typing import Dict, List, Mapping, MutableMapping, Protocol, Sequence
+
+
+class ChatCompletionClient(Protocol):
+    """Protocol describing the subset of LLM client functionality we use."""
+
+    def complete(self, messages: Sequence[Mapping[str, str]]) -> str:
+        """Return the generated message content for the provided conversation."""
 
 
 class IntentParser:
-    """Rule-based interpreter translating chat messages into structured intents."""
+    """Interpreter translating chat messages into structured intents."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        llm_client: ChatCompletionClient | None = None,
+        context_window: int = 5,
+    ) -> None:
+        self._llm_client = llm_client
+        self._context_window = max(0, context_window)
         self._scenario_pattern = re.compile(r"scenario[s]?\s+([\w,\- ]+)", re.IGNORECASE)
 
-    def parse(self, message: str) -> Dict[str, object]:
+    def parse(
+        self,
+        message: str,
+        *,
+        context: Sequence[Mapping[str, str]] | None = None,
+    ) -> Dict[str, object]:
         """Return a structured representation of the requested action."""
 
+        if self._llm_client:
+            llm_intent = self._attempt_llm_parse(message, context=context)
+            if llm_intent:
+                return llm_intent
+
+        return self._rule_based_parse(message)
+
+    # ------------------------------------------------------------------
+    # Rule-based parsing fallback
+    def _rule_based_parse(self, message: str) -> Dict[str, object]:
         lowered = message.lower()
         if any(keyword in lowered for keyword in ["run", "simulate", "execute", "运行", "模拟"]):
             scenario_ids = self._extract_scenarios(message)
@@ -35,6 +65,87 @@ class IntentParser:
             return {"action": "summarise_results", "parameters": {}, "confidence": 0.5}
         return {"action": "general_chat", "parameters": {}, "confidence": 0.2}
 
+    # ------------------------------------------------------------------
+    # LLM helpers
+    def _attempt_llm_parse(
+        self,
+        message: str,
+        *,
+        context: Sequence[Mapping[str, str]] | None,
+    ) -> Dict[str, object] | None:
+        if not self._llm_client:
+            return None
+
+        llm_messages = self._build_llm_messages(message, context=context)
+        try:
+            response = self._llm_client.complete(llm_messages)
+        except Exception:  # pragma: no cover - defensive fallback
+            return None
+
+        candidate = self._parse_llm_response(response)
+        if candidate is None:
+            return None
+        return candidate
+
+    def _build_llm_messages(
+        self,
+        message: str,
+        *,
+        context: Sequence[Mapping[str, str]] | None,
+    ) -> List[Mapping[str, str]]:
+        system_prompt = (
+            "You are a helpful assistant for a hydrological modelling portal. "
+            "Analyse the conversation and classify the user's latest message into an action. "
+            "Only respond with valid JSON using the schema: {\"action\": string, \"parameters\": object, \"confidence\": number}."
+        )
+
+        llm_messages: List[MutableMapping[str, str]] = [
+            {"role": "system", "content": system_prompt}
+        ]
+
+        if context:
+            trimmed_context = list(context)[-self._context_window :]
+            for item in trimmed_context:
+                role = item.get("role", "user")
+                content = item.get("content")
+                if isinstance(content, str):
+                    llm_messages.append({"role": role, "content": content})
+
+        llm_messages.append({"role": "user", "content": message})
+        return llm_messages
+
+    def _parse_llm_response(self, response: str) -> Dict[str, object] | None:
+        try:
+            data = json.loads(response)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(data, Mapping):
+            return None
+
+        action = data.get("action")
+        if not isinstance(action, str) or not action:
+            return None
+
+        parameters = data.get("parameters")
+        if parameters is None:
+            parameters = {}
+        elif not isinstance(parameters, Mapping):
+            return None
+
+        intent: Dict[str, object] = {
+            "action": action,
+            "parameters": dict(parameters),
+        }
+
+        confidence = data.get("confidence")
+        if isinstance(confidence, (int, float)):
+            intent["confidence"] = float(confidence)
+
+        return intent
+
+    # ------------------------------------------------------------------
+    # Regex helpers
     def _extract_scenarios(self, message: str) -> List[str]:
         match = self._scenario_pattern.search(message)
         if not match:
@@ -43,10 +154,12 @@ class IntentParser:
         return [item for item in candidates if item]
 
     def _extract_name(self, message: str) -> str | None:
-        name_match = re.search(r"scenario\s+(?:called|named)?\s*([\w\-]+)", message, re.IGNORECASE)
+        name_match = re.search(
+            r"scenario\s+(?:called|named)?\s*([\w\-]+)", message, re.IGNORECASE
+        )
         if name_match:
             return name_match.group(1)
         return None
 
 
-__all__ = ["IntentParser"]
+__all__ = ["ChatCompletionClient", "IntentParser"]

--- a/hydrosis/portal/providers/__init__.py
+++ b/hydrosis/portal/providers/__init__.py
@@ -1,0 +1,6 @@
+"""LLM provider implementations for the HydroSIS portal."""
+from __future__ import annotations
+
+from .qwen import QwenClient, QwenClientError
+
+__all__ = ["QwenClient", "QwenClientError"]

--- a/hydrosis/portal/providers/qwen.py
+++ b/hydrosis/portal/providers/qwen.py
@@ -1,0 +1,120 @@
+"""Client wrapper for the Qwen chat completion API."""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Mapping, MutableMapping, Sequence
+
+
+class QwenClientError(RuntimeError):
+    """Raised when the Qwen API returns an error."""
+
+
+class QwenClient:
+    """Minimal client for interacting with the Qwen chat completion endpoint."""
+
+    _DEFAULT_ENDPOINT = (
+        "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+    )
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        base_url: str | None = None,
+        timeout: float | None = 30.0,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key is required to use the Qwen client")
+        if not model:
+            raise ValueError("model is required to use the Qwen client")
+        self._api_key = api_key
+        self._model = model
+        self._endpoint = base_url or self._DEFAULT_ENDPOINT
+        self._timeout = timeout
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        api_key_env: str = "QWEN_API_KEY",
+        model_env: str = "QWEN_MODEL",
+        default_model: str | None = "qwen-turbo",
+        base_url_env: str = "QWEN_BASE_URL",
+    ) -> "QwenClient | None":
+        """Instantiate the client from standard environment variables."""
+
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            return None
+        model = os.environ.get(model_env) or default_model
+        base_url = os.environ.get(base_url_env)
+        if not model:
+            return None
+        return cls(api_key=api_key, model=model, base_url=base_url)
+
+    def complete(
+        self,
+        messages: Sequence[Mapping[str, str]],
+        *,
+        extra_parameters: Mapping[str, object] | None = None,
+    ) -> str:
+        """Send a chat completion request and return the message content."""
+
+        payload: MutableMapping[str, object] = {
+            "model": self._model,
+            "messages": [dict(message) for message in messages],
+        }
+        if extra_parameters:
+            payload.update(dict(extra_parameters))
+
+        request = urllib.request.Request(
+            self._endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._api_key}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as response:
+                raw_body = response.read().decode("utf-8")
+        except urllib.error.URLError as exc:  # pragma: no cover - network failure
+            raise QwenClientError("Failed to reach Qwen API") from exc
+
+        try:
+            body = json.loads(raw_body)
+        except json.JSONDecodeError as exc:
+            raise QwenClientError("Invalid response from Qwen API") from exc
+
+        if isinstance(body, Mapping) and "error" in body:
+            error = body["error"]
+            if isinstance(error, Mapping):
+                message = error.get("message") or "Qwen API error"
+            else:
+                message = "Qwen API error"
+            raise QwenClientError(str(message))
+
+        choices = body.get("choices") if isinstance(body, Mapping) else None
+        if not choices:
+            raise QwenClientError("Qwen API response did not contain choices")
+
+        first_choice = choices[0]
+        if not isinstance(first_choice, Mapping):
+            raise QwenClientError("Unexpected response structure from Qwen API")
+
+        message = first_choice.get("message")
+        if not isinstance(message, Mapping):
+            raise QwenClientError("Qwen API response missing message content")
+
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise QwenClientError("Qwen API response content must be a string")
+        return content
+
+
+__all__ = ["QwenClient", "QwenClientError"]

--- a/tests/test_intent_parser.py
+++ b/tests/test_intent_parser.py
@@ -1,0 +1,52 @@
+"""Unit tests for the portal intent parser and LLM integration."""
+from __future__ import annotations
+
+from typing import List, Mapping, Sequence
+
+from hydrosis.portal.llm import IntentParser
+
+
+class DummyLLMClient:
+    """Simple stand-in for an LLM chat completion client."""
+
+    def __init__(self, responses: Sequence[str], *, raise_on_call: bool = False) -> None:
+        self._responses = list(responses)
+        self.raise_on_call = raise_on_call
+        self.calls: List[Sequence[Mapping[str, str]]] = []
+
+    def complete(self, messages: Sequence[Mapping[str, str]]) -> str:
+        self.calls.append(messages)
+        if self.raise_on_call:
+            raise RuntimeError("simulated failure")
+        if not self._responses:
+            raise AssertionError("No more responses configured for dummy client")
+        return self._responses.pop(0)
+
+
+def test_intent_parser_llm_success_path() -> None:
+    client = DummyLLMClient(
+        ['{"action": "run_scenarios", "parameters": {"scenario_ids": ["baseline"]}, "confidence": 0.85}']
+    )
+    parser = IntentParser(llm_client=client)
+
+    context = [{"role": "assistant", "content": "How can I help with your hydrology project?"}]
+    intent = parser.parse("Please run the baseline scenario", context=context)
+
+    assert intent["action"] == "run_scenarios"
+    assert intent["parameters"] == {"scenario_ids": ["baseline"]}
+    assert intent["confidence"] == 0.85
+
+    assert client.calls, "Expected the LLM client to be invoked"
+    llm_messages = client.calls[0]
+    assert llm_messages[0]["role"] == "system"
+    assert llm_messages[-1]["content"].endswith("baseline scenario")
+
+
+def test_intent_parser_llm_failure_falls_back_to_rules() -> None:
+    client = DummyLLMClient(['{"unexpected": "value"}'], raise_on_call=True)
+    parser = IntentParser(llm_client=client)
+
+    intent = parser.parse("Run scenario S1")
+
+    assert intent["action"] == "run_scenarios"
+    assert intent["parameters"]["scenario_ids"] == ["S1"]


### PR DESCRIPTION
## Summary
- add a Qwen chat completion provider for invoking DashScope-compatible models
- allow the portal intent parser to optionally use an injected LLM client with conversation context
- wire Qwen configuration into app creation and cover success/fallback paths with unit tests

## Testing
- pytest tests/test_intent_parser.py
- pytest tests/test_portal_api.py -k end_to_end --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68cdf0ed28a48330a0af26809d52aaa0