### PR TITLE
Add Qwen narrative integration and automated injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,21 @@ workflow = run_workflow(
     persist_outputs=True,
     generate_report=True,
     report_template=default_evaluation_template(),
-    narrative_callback=lambda prompt: f"（示例 LLM 输出）{prompt}",
+    llm_provider="qwen",  # 需提前设置千问 API 凭据
 )
 print("Markdown 报告：", workflow.report_path)
 ```
+
+要启用千问（Qwen）生成摘要，请在执行前设置以下环境变量：
+
+```bash
+export DASHSCOPE_API_KEY="<你的千问 API Key>"
+export HYDROSIS_LLM_PROVIDER=qwen
+```
+
+随后调用 `run_workflow(..., llm_provider="qwen")` 或在配置文件/模板上下文中写入
+`llm_provider: qwen` 即可自动注入大模型回调。若仅希望使用本地示例占位，可省略
+上述变量，框架会退回到固定的演示文本。
 
 ### 示例运行与输出
 
@@ -228,7 +239,8 @@ summary = analyzer.analyse({"Z1": bootstrap_sampler}, draws=200)
 ## 报告模板与大模型说明
 
 - `hydrosis.reporting.templates` 提供默认的“模型运行概述—关键发现—后续建议”结构，可按需自定义。
-- 将 `narrative_callback` 指向大模型调用函数，即可把模板提示词转换为自然语言段落，实现自动撰写摘要。
+- 提供 `hydrosis.reporting.narratives.qwen_narrative`，可直接接入千问 API。
+- 将 `llm_provider` 设置为 `qwen`（支持环境变量 `HYDROSIS_LLM_PROVIDER`、配置字段或模板上下文）后，无需手动传入回调即可自动调用千问生成摘要。
 - `template_context` 支持预填固定文本，结合模型指标自动生成简明结论，再用大模型补充细节。
 
 ## 与大模型集成

--- a/examples/run_sample_workflow.py
+++ b/examples/run_sample_workflow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import sys
 from typing import Dict, List, Mapping, Sequence
@@ -182,14 +183,25 @@ def main() -> None:
     if observations is None:
         observations = _load_observations(config.io.discharge_observations)
 
+    workflow_kwargs: dict[str, object] = {
+        "persist_outputs": True,
+        "generate_report": True,
+        "report_template": default_evaluation_template(),
+    }
+    provider_env = os.environ.get("HYDROSIS_LLM_PROVIDER")
+    if provider_env:
+        workflow_kwargs["llm_provider"] = provider_env
+    else:
+        workflow_kwargs["narrative_callback"] = (
+            lambda prompt: f"（示例 LLM 输出）{prompt}"
+        )
+
     workflow_result = run_workflow(
         config,
         forcing,
         observations=observations,
-        persist_outputs=True,
-        generate_report=True,
-        report_template=default_evaluation_template(),
-        narrative_callback=lambda prompt: f"（示例 LLM 输出）{prompt}",
+        template_context=None,
+        **workflow_kwargs,
     )
 
     print("Baseline aggregated discharge (first 5 values):")

--- a/hydrosis/__init__.py
+++ b/hydrosis/__init__.py
@@ -12,6 +12,7 @@ from .reporting import (
     render_template,
     EvaluationReportTemplate,
     ReportSection,
+    qwen_narrative,
 )
 from .model import HydroSISModel
 from .utils import accumulate_subbasin_flows
@@ -38,6 +39,7 @@ __all__ = [
     "render_template",
     "EvaluationReportTemplate",
     "ReportSection",
+    "qwen_narrative",
     "accumulate_subbasin_flows",
     "ObjectiveDefinition",
     "OptimizationResult",

--- a/hydrosis/config.py
+++ b/hydrosis/config.py
@@ -58,6 +58,8 @@ class EvaluationConfig:
         default_factory=lambda: ["rmse", "mae", "pbias", "nse"]
     )
     comparisons: List[ComparisonPlanConfig] = field(default_factory=list)
+    llm_provider: Optional[str] = None
+    llm_model: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: Mapping[str, object]) -> "EvaluationConfig":
@@ -67,12 +69,16 @@ class EvaluationConfig:
                 ComparisonPlanConfig.from_dict(item)
                 for item in data.get("comparisons", [])
             ],
+            llm_provider=data.get("llm_provider"),
+            llm_model=data.get("llm_model"),
         )
 
     def to_dict(self) -> Dict[str, object]:
         return {
             "metrics": list(self.metrics),
             "comparisons": [cfg.to_dict() for cfg in self.comparisons],
+            "llm_provider": self.llm_provider,
+            "llm_model": self.llm_model,
         }
 
 

--- a/hydrosis/reporting/__init__.py
+++ b/hydrosis/reporting/__init__.py
@@ -6,6 +6,7 @@ from .markdown import (
     generate_evaluation_report,
     summarise_aggregated_metrics,
 )
+from .narratives import qwen_narrative
 from .templates import (
     EvaluationReportTemplate,
     ReportSection,
@@ -23,4 +24,5 @@ __all__ = [
     "ReportSection",
     "default_evaluation_template",
     "render_template",
+    "qwen_narrative",
 ]

--- a/hydrosis/reporting/narratives.py
+++ b/hydrosis/reporting/narratives.py
@@ -1,0 +1,103 @@
+"""LLM-backed narrative helpers for HydroSIS reports."""
+from __future__ import annotations
+
+import json
+import os
+import socket
+from typing import Any, Dict
+from urllib import error, request
+
+__all__ = ["qwen_narrative"]
+
+
+_DASHSCOPE_COMPATIBLE_ENDPOINT = (
+    "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+)
+
+
+def _load_api_key(explicit: str | None) -> str:
+    api_key = (
+        explicit
+        or os.environ.get("DASHSCOPE_API_KEY")
+        or os.environ.get("QWEN_API_KEY")
+    )
+    if not api_key:
+        raise RuntimeError(
+            "Qwen API key missing. Provide it via the api_key argument or set "
+            "the DASHSCOPE_API_KEY/QWEN_API_KEY environment variable."
+        )
+    return api_key
+
+
+def _build_payload(prompt: str, model: str) -> Dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt,
+            }
+        ],
+    }
+
+
+def _decode_response(data: bytes) -> str:
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+        raise RuntimeError("Failed to decode Qwen API response as JSON") from exc
+
+    choices = payload.get("choices")
+    if not choices:
+        raise RuntimeError("Qwen API response did not include any choices")
+
+    first = choices[0]
+    message = first.get("message") if isinstance(first, dict) else None
+    if not message or "content" not in message:
+        raise RuntimeError("Qwen API response missing message content")
+
+    return str(message["content"]).strip()
+
+
+def qwen_narrative(
+    prompt: str,
+    *,
+    api_key: str | None = None,
+    model: str = "qwen-plus",
+) -> str:
+    """Generate a markdown narrative by calling the Qwen chat-completions API.
+
+    The function posts the supplied ``prompt`` to DashScope's OpenAI-compatible
+    endpoint and returns the textual content from the first choice. Network
+    failures, server errors and malformed responses are surfaced as
+    :class:`RuntimeError` exceptions with descriptive messages.
+    """
+
+    payload = json.dumps(_build_payload(prompt, model)).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {_load_api_key(api_key)}",
+    }
+    req = request.Request(
+        _DASHSCOPE_COMPATIBLE_ENDPOINT,
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+
+    try:
+        with request.urlopen(req, timeout=30) as response:
+            response_body = response.read()
+    except error.HTTPError as exc:
+        detail: str
+        try:
+            detail = exc.read().decode("utf-8", "ignore")
+        except Exception:  # pragma: no cover - highly defensive
+            detail = str(exc)
+        raise RuntimeError(
+            f"Qwen API request failed with status {exc.code}: {detail}"
+        ) from None
+    except (error.URLError, socket.timeout, OSError) as exc:
+        raise RuntimeError(f"Qwen API request failed: {exc}") from None
+
+    return _decode_response(response_body)


### PR DESCRIPTION
## Summary
- add a Qwen-powered narrative helper and wire it into the report generator so LLM callbacks can be auto-resolved from configuration, context, or environment hints
- extend the workflow/configuration plumbing to surface llm_provider/model settings and pass them through to report creation
- document the new setup flow and update the sample workflow plus tests to exercise the integration without network access

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cdf0edb4608330879a7dc6c5c7f8f3